### PR TITLE
feat: add Peperoncino GitHub Action integration

### DIFF
--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -1,0 +1,71 @@
+name: Peperoncino Action Smoke Test
+
+on:
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - action.yml
+      - folia-phantom/**
+      - .github/workflows/action-smoke.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: peperoncino-action-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Patch a fixture plugin
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create fixture plugin
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          import zipfile
+
+          plugin_yml = """name: PeperoncinoSmoke
+          version: 1.0.0
+          main: dev.marv.peperoncino.SmokePlugin
+          api-version: '1.21'
+          """
+
+          with zipfile.ZipFile("smoke-plugin.jar", "w", compression=zipfile.ZIP_DEFLATED) as jar:
+              jar.writestr("plugin.yml", plugin_yml)
+          PY
+
+      - name: Run pasta action
+        id: pasta
+        uses: ./
+        with:
+          input: smoke-plugin.jar
+          output: action-output
+
+      - name: Verify patched artifact
+        shell: bash
+        env:
+          PASTA_PATCHED_COUNT: ${{ steps.pasta.outputs.patched_count }}
+          PASTA_OUTPUT_DIRECTORY: ${{ steps.pasta.outputs.output_directory }}
+        run: |
+          set -euo pipefail
+          test "$PASTA_PATCHED_COUNT" = "1"
+          test "$PASTA_OUTPUT_DIRECTORY" = "$GITHUB_WORKSPACE/action-output"
+          test -f action-output/patched-smoke-plugin.jar
+
+          python3 - <<'PY'
+          import zipfile
+
+          with zipfile.ZipFile("action-output/patched-smoke-plugin.jar") as jar:
+              plugin_yml = jar.read("plugin.yml").decode("utf-8")
+
+          if "folia-supported: true" not in plugin_yml:
+              raise SystemExit("patched plugin.yml does not declare Folia support")
+          PY

--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create fixture plugin
         shell: bash

--- a/PEPERONCINO.md
+++ b/PEPERONCINO.md
@@ -81,6 +81,17 @@ Peperoncino automates pasta's existing transformation. It does **not** prove tha
 
 A green Action run means that pasta successfully produced the transformed artifact. It must not be presented as a formal Folia compatibility certification.
 
+Input plugin JARs are treated as untrusted archives. The patcher rejects inputs that exceed any of these default resource limits before they can grow without bound in memory:
+
+| Limit | Default |
+|---|---:|
+| Compressed input JAR size | 256 MiB |
+| Expanded size of one JAR entry | 64 MiB |
+| Total expanded JAR size | 512 MiB |
+| JAR entry count | 100,000 |
+
+The expanded-size and entry-count limits apply to every archive entry, including directories and signature files that pasta later discards. This prevents skipped entries from bypassing the archive resource boundary.
+
 Future Peperoncino work can add static-analysis/reporting signals separately from transformation so CI can distinguish:
 
 - transformation success;
@@ -96,3 +107,5 @@ The repository includes `.github/workflows/action-smoke.yml`, which:
 2. runs the repository's own `action.yml`;
 3. verifies exactly one output JAR is created;
 4. verifies the patched `plugin.yml` contains `folia-supported: true`.
+
+The core test suite also covers compressed-input, per-entry expansion, total expansion, entry-count, discarded signature-entry, and normal-plugin cases for the JAR resource boundary.

--- a/PEPERONCINO.md
+++ b/PEPERONCINO.md
@@ -20,9 +20,9 @@ jobs:
   folia:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
@@ -73,7 +73,7 @@ This has two useful properties:
 1. the action and transformer code cannot drift to different revisions;
 2. Peperoncino does not introduce another binary distribution channel yet.
 
-The trade-off is build time. Maven dependency caching is enabled, but a future Peperoncino milestone may use signed release artifacts after the release pipeline and provenance model are ready.
+The trade-off is build time. The initial milestone relies on the runner's local Maven repository rather than adding action-owned cache key logic. A future Peperoncino milestone may use signed release artifacts and explicit dependency caching after the release pipeline and provenance model are ready.
 
 ## Safety boundary
 

--- a/PEPERONCINO.md
+++ b/PEPERONCINO.md
@@ -1,0 +1,98 @@
+# Peperoncino
+
+Peperoncino is the GitHub Actions integration update for pasta.
+
+The first Peperoncino milestone makes pasta usable directly from a plugin repository's CI pipeline without copying CLI commands into every project.
+
+## GitHub Action
+
+A workflow can patch a built Bukkit plugin JAR with pasta:
+
+```yaml
+name: Folia artifact
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  folia:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Build plugin
+        run: mvn --batch-mode --no-transfer-progress package
+
+      - name: Patch for Folia
+        id: pasta
+        uses: MARVserver/pasta@develop
+        with:
+          input: target/my-plugin.jar
+          output: build/pasta
+
+      - name: Upload Folia artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: my-plugin-folia
+          path: ${{ steps.pasta.outputs.output_directory }}/patched-my-plugin.jar
+```
+
+`@develop` is appropriate while Peperoncino is unreleased. Production workflows should pin a released tag or immutable commit SHA once a Peperoncino release is published.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---:|---|---|
+| `input` | yes | — | Plugin JAR or directory. Relative paths are resolved from `GITHUB_WORKSPACE`. |
+| `output` | no | `patched-plugins` | Output directory for patched JARs. |
+| `java-version` | no | `21` | JDK used to build and run pasta. |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `output_directory` | Absolute directory containing the patched JARs. |
+| `patched_count` | Number of `patched-*.jar` files produced. |
+
+The action fails when the input does not exist, the pasta CLI cannot be built unambiguously, or no patched JAR is produced. This makes path/configuration mistakes visible as CI failures instead of silently succeeding.
+
+## Current execution model
+
+The composite action intentionally builds the pasta CLI from the exact action revision being used, then invokes the existing CLI with `--no-banner` and `--output`.
+
+This has two useful properties:
+
+1. the action and transformer code cannot drift to different revisions;
+2. Peperoncino does not introduce another binary distribution channel yet.
+
+The trade-off is build time. Maven dependency caching is enabled, but a future Peperoncino milestone may use signed release artifacts after the release pipeline and provenance model are ready.
+
+## Safety boundary
+
+Peperoncino automates pasta's existing transformation. It does **not** prove that arbitrary plugin state is thread-safe under Folia.
+
+A green Action run means that pasta successfully produced the transformed artifact. It must not be presented as a formal Folia compatibility certification.
+
+Future Peperoncino work can add static-analysis/reporting signals separately from transformation so CI can distinguish:
+
+- transformation success;
+- suspicious shared mutable state;
+- region/entity/global scheduler ownership findings;
+- manual-review requirements.
+
+## Verification
+
+The repository includes `.github/workflows/action-smoke.yml`, which:
+
+1. creates a minimal plugin JAR fixture;
+2. runs the repository's own `action.yml`;
+3. verifies exactly one output JAR is created;
+4. verifies the patched `plugin.yml` contains `folia-supported: true`.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ Using ASM 9.7, pasta rewrites compiled `.class` files without requiring plugin s
 
 > Bytecode transformation cannot guarantee that every Bukkit plugin is Folia-safe. Test patched plugins on a staging server before production use.
 
+## Peperoncino update
+
+**Peperoncino** adds first-class GitHub Actions integration so plugin projects can run pasta directly in CI. The initial milestone adds:
+
+- a root [`action.yml`](action.yml) composite action;
+- `input`, `output`, and `java-version` inputs;
+- `output_directory` and `patched_count` outputs for downstream workflow steps;
+- clear CI failures when an input is missing or no patched JAR is produced;
+- an end-to-end smoke workflow that patches a generated fixture plugin;
+- usage, execution-model, and safety documentation in [`PEPERONCINO.md`](PEPERONCINO.md).
+
+Peperoncino deliberately reuses the existing CLI and does not change transformer semantics. A successful Action run means that pasta produced a transformed artifact; it is not a formal certification that arbitrary plugin state is thread-safe under Folia.
+
 ## Carbonara update
 
 **Carbonara** is the current usability and contributor-experience update. It adds:
@@ -40,6 +53,7 @@ Carbonara does not change the project's `2.0.0` version by itself; versioning re
 | Mode | Best for | Requires |
 |------|----------|----------|
 | **Browser** | Quick local patching without installing a desktop app | Modern browser |
+| **GitHub Actions** | Producing Folia-patched artifacts in CI | GitHub Actions runner with Maven |
 | **CLI** | Automation and batch patching | Java 21+ recommended/validated |
 | **GUI** | Desktop drag-and-drop workflows | Java 21+ recommended/validated |
 | **Server plugin** | Patching from a Bukkit/Paper server | Java 21+ Paper-compatible server |
@@ -53,6 +67,27 @@ The static app under `web/` runs the Java patcher through CheerpJ. Plugin JARs a
 3. Review which files are ready or will be skipped.
 4. Patch and download the resulting `patched-*.jar` files.
 5. Download `pasta-report.csv` when you need a batch transformation report.
+
+### GitHub Actions
+
+Peperoncino exposes pasta as a composite action. While the update is unreleased, workflows can reference `develop`; production workflows should pin a release tag or immutable commit SHA once published.
+
+```yaml
+- name: Patch for Folia
+  id: pasta
+  uses: MARVserver/pasta@develop
+  with:
+    input: target/my-plugin.jar
+    output: build/pasta
+
+- name: Upload patched artifact
+  uses: actions/upload-artifact@v4
+  with:
+    name: my-plugin-folia
+    path: ${{ steps.pasta.outputs.output_directory }}/patched-my-plugin.jar
+```
+
+See [`PEPERONCINO.md`](PEPERONCINO.md) for the full workflow, inputs, outputs, safety boundary, and planned analyzer direction.
 
 ### CLI
 
@@ -113,7 +148,7 @@ The JavaFX app provides drag-and-drop file selection, per-file state indicators,
 - **Runtime bridge bundling** — includes Folia runtime adapter classes in patched JARs.
 - **Fast-fail scanning** — skips classes that do not require rewriting.
 - **Parallel transformation** — uses a `ForkJoinPool` for CPU-heavy class processing outside constrained browser execution.
-- **Multiple frontends** — browser, CLI, desktop GUI, and server plugin workflows share the same transformation core.
+- **Multiple frontends** — browser, CLI, desktop GUI, server plugin, and GitHub Actions workflows share the same transformation core.
 
 ## Modules
 
@@ -145,6 +180,8 @@ Transformer order is intentional because rewrites may depend on earlier normaliz
 - pasta-owned Java classes are currently compiled with Maven `--release 17`; this bytecode target is separate from the JDK required to resolve Java 21 Paper dependencies.
 
 For packaged CLI/GUI/server workflows, Java 21 is the supported baseline used by CI. The browser frontend uses its own CheerpJ execution path, so changes to the emitted bytecode target require coordinated browser testing.
+
+For the GitHub Action, `actions/setup-java` selects the requested JDK and the runner must provide Maven. GitHub-hosted Ubuntu runners are the validated baseline for the initial Peperoncino milestone.
 
 ## Build
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,100 @@
+name: "pasta — Peperoncino"
+description: "Patch Bukkit plugin JARs for Folia in GitHub Actions using pasta."
+author: "MARVserver"
+
+branding:
+  icon: "package"
+  color: "red"
+
+inputs:
+  input:
+    description: "Plugin JAR or directory to patch. Relative paths are resolved from GITHUB_WORKSPACE."
+    required: true
+  output:
+    description: "Directory for patched JARs. Relative paths are resolved from GITHUB_WORKSPACE."
+    required: false
+    default: "patched-plugins"
+  java-version:
+    description: "JDK used to build and run pasta."
+    required: false
+    default: "21"
+
+outputs:
+  output_directory:
+    description: "Absolute directory containing patched JARs."
+    value: ${{ steps.patch.outputs.output_directory }}
+  patched_count:
+    description: "Number of patched JARs produced by this invocation."
+    value: ${{ steps.patch.outputs.patched_count }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: "temurin"
+        java-version: ${{ inputs.java-version }}
+        cache: "maven"
+        cache-dependency-path: ${{ github.action_path }}/folia-phantom/pom.xml
+
+    - name: Build pasta CLI
+      shell: bash
+      run: |
+        set -euo pipefail
+        mvn \
+          --batch-mode \
+          --no-transfer-progress \
+          -f "$GITHUB_ACTION_PATH/folia-phantom/pom.xml" \
+          -pl folia-phantom-cli \
+          -am \
+          -DskipTests \
+          package
+
+    - name: Patch plugin JARs
+      id: patch
+      shell: bash
+      env:
+        PASTA_INPUT: ${{ inputs.input }}
+        PASTA_OUTPUT: ${{ inputs.output }}
+      run: |
+        set -euo pipefail
+
+        resolve_workspace_path() {
+          local value="$1"
+          if [[ "$value" = /* ]]; then
+            printf '%s\n' "$value"
+          else
+            printf '%s/%s\n' "$GITHUB_WORKSPACE" "$value"
+          fi
+        }
+
+        input_path="$(resolve_workspace_path "$PASTA_INPUT")"
+        output_dir="$(resolve_workspace_path "$PASTA_OUTPUT")"
+
+        if [[ ! -e "$input_path" ]]; then
+          echo "::error::pasta input does not exist: $input_path"
+          exit 1
+        fi
+
+        shopt -s nullglob
+        cli_jars=("$GITHUB_ACTION_PATH"/folia-phantom/folia-phantom-cli/target/Folia-Phantom-CLI-*.jar)
+        shopt -u nullglob
+
+        if [[ ${#cli_jars[@]} -ne 1 ]]; then
+          echo "::error::Expected exactly one pasta CLI JAR, found ${#cli_jars[@]}."
+          exit 1
+        fi
+
+        mkdir -p "$output_dir"
+        java -jar "${cli_jars[0]}" --no-banner --output "$output_dir" -- "$input_path"
+
+        patched_count="$(find "$output_dir" -maxdepth 1 -type f -name 'patched-*.jar' | wc -l | tr -d '[:space:]')"
+        if [[ "$patched_count" -eq 0 ]]; then
+          echo "::error::pasta completed without producing a patched JAR."
+          exit 1
+        fi
+
+        echo "output_directory=$output_dir" >> "$GITHUB_OUTPUT"
+        echo "patched_count=$patched_count" >> "$GITHUB_OUTPUT"
+        echo "pasta produced $patched_count patched JAR(s) in $output_dir"

--- a/action.yml
+++ b/action.yml
@@ -31,12 +31,10 @@ runs:
   using: "composite"
   steps:
     - name: Set up Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: "temurin"
         java-version: ${{ inputs.java-version }}
-        cache: "maven"
-        cache-dependency-path: ${{ github.action_path }}/folia-phantom/pom.xml
 
     - name: Build pasta CLI
       shell: bash

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/PluginPatcher.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/PluginPatcher.java
@@ -45,10 +45,11 @@ public final class PluginPatcher {
 
     private static final Logger log = LoggerFactory.getLogger(PluginPatcher.class);
     private static final int ASM_API = Opcodes.ASM9;
-    private static final long MAX_INPUT_BYTES = 256L * 1024 * 1024;
-    private static final long MAX_ENTRY_UNCOMPRESSED_BYTES = 64L * 1024 * 1024;
-    private static final long MAX_TOTAL_UNCOMPRESSED_BYTES = 512L * 1024 * 1024;
-    private static final int MAX_ENTRY_COUNT = 100_000;
+    private static final JarResourceLimits DEFAULT_RESOURCE_LIMITS = new JarResourceLimits(
+            256L * 1024 * 1024,
+            64L * 1024 * 1024,
+            512L * 1024 * 1024,
+            100_000);
     private static final byte[] BUKKIT_CONSTANT_POOL_MARKER =
             "org/bukkit/".getBytes(StandardCharsets.US_ASCII);
     private static final String[] RUNTIME_CLASSES = {
@@ -64,6 +65,7 @@ public final class PluginPatcher {
     private final Path outputDir;
     private final boolean verbose;
     private final boolean parallel;
+    private final JarResourceLimits resourceLimits;
     private final AtomicInteger patchedClassCount = new AtomicInteger();
     private final AtomicInteger skippedClassCount = new AtomicInteger();
     private final AtomicInteger failedClassCount = new AtomicInteger();
@@ -80,9 +82,18 @@ public final class PluginPatcher {
      *                 disable this to avoid worker/thread emulation overhead and improve stability.
      */
     public PluginPatcher(Path outputDir, boolean verbose, boolean parallel) {
+        this(outputDir, verbose, parallel, DEFAULT_RESOURCE_LIMITS);
+    }
+
+    PluginPatcher(
+            Path outputDir,
+            boolean verbose,
+            boolean parallel,
+            JarResourceLimits resourceLimits) {
         this.outputDir = outputDir;
         this.verbose = verbose;
         this.parallel = parallel;
+        this.resourceLimits = resourceLimits;
         int processors = Runtime.getRuntime().availableProcessors();
         int parallelism = Math.max(1, processors > 2 ? processors - 1 : processors);
         this.forkJoinPool = parallel ? new ForkJoinPool(parallelism) : null;
@@ -101,8 +112,9 @@ public final class PluginPatcher {
             return jarPath;
         }
         long inputSize = Files.size(jarPath);
-        if (inputSize > MAX_INPUT_BYTES) {
-            throw new IOException("Plugin JAR exceeds maximum input size of " + MAX_INPUT_BYTES + " bytes: " + fileName);
+        if (inputSize > resourceLimits.maxInputBytes()) {
+            throw new IOException("Plugin JAR exceeds maximum input size of "
+                    + resourceLimits.maxInputBytes() + " bytes: " + fileName);
         }
 
         long startedAt = System.nanoTime();
@@ -148,21 +160,28 @@ public final class PluginPatcher {
         try (JarInputStream input = new JarInputStream(Files.newInputStream(jarPath))) {
             JarEntry entry;
             while ((entry = input.getNextJarEntry()) != null) {
-                String name = entry.getName();
-                if (entry.isDirectory() || isSignatureFile(name)) {
-                    continue;
-                }
                 entryCount++;
-                if (entryCount > MAX_ENTRY_COUNT) {
-                    throw new IOException("Plugin JAR exceeds maximum entry count of " + MAX_ENTRY_COUNT);
+                if (entryCount > resourceLimits.maxEntryCount()) {
+                    throw new IOException("Plugin JAR exceeds maximum entry count of "
+                            + resourceLimits.maxEntryCount());
                 }
 
-                byte[] content = readEntryBounded(input, name);
-                totalUncompressedBytes += content.length;
-                if (totalUncompressedBytes > MAX_TOTAL_UNCOMPRESSED_BYTES) {
-                    throw new IOException("Plugin JAR exceeds maximum expanded size of "
-                            + MAX_TOTAL_UNCOMPRESSED_BYTES + " bytes");
+                String name = entry.getName();
+                boolean retainContent = !entry.isDirectory() && !isSignatureFile(name);
+                long remainingTotalBytes = resourceLimits.maxTotalUncompressedBytes()
+                        - totalUncompressedBytes;
+                ReadEntryResult readResult = readEntryBounded(
+                        input,
+                        entry,
+                        remainingTotalBytes,
+                        retainContent);
+                totalUncompressedBytes += readResult.uncompressedBytes();
+
+                if (!retainContent) {
+                    continue;
                 }
+
+                byte[] content = readResult.content();
                 if ("plugin.yml".equals(name)) {
                     entries.add(PreparedEntry.direct(name, modifyPluginYml(content)));
                 } else if (name.endsWith(".class")) {
@@ -181,20 +200,49 @@ public final class PluginPatcher {
         return entries;
     }
 
-    private static byte[] readEntryBounded(InputStream input, String entryName) throws IOException {
-        ByteArrayOutputStream output = new ByteArrayOutputStream();
+    private ReadEntryResult readEntryBounded(
+            InputStream input,
+            JarEntry entry,
+            long remainingTotalBytes,
+            boolean retainContent) throws IOException {
+        long declaredSize = entry.getSize();
+        if (declaredSize > resourceLimits.maxEntryUncompressedBytes()) {
+            throw entrySizeLimitException();
+        }
+        if (declaredSize > remainingTotalBytes) {
+            throw totalSizeLimitException();
+        }
+
+        ByteArrayOutputStream output = retainContent ? new ByteArrayOutputStream() : null;
         byte[] buffer = new byte[8192];
         long entryBytes = 0;
         int read;
         while ((read = input.read(buffer)) != -1) {
-            entryBytes += read;
-            if (entryBytes > MAX_ENTRY_UNCOMPRESSED_BYTES) {
-                throw new IOException("JAR entry exceeds maximum expanded size of "
-                        + MAX_ENTRY_UNCOMPRESSED_BYTES + " bytes: " + entryName);
+            if (read == 0) {
+                continue;
             }
-            output.write(buffer, 0, read);
+            entryBytes += read;
+            if (entryBytes > resourceLimits.maxEntryUncompressedBytes()) {
+                throw entrySizeLimitException();
+            }
+            if (entryBytes > remainingTotalBytes) {
+                throw totalSizeLimitException();
+            }
+            if (output != null) {
+                output.write(buffer, 0, read);
+            }
         }
-        return output.toByteArray();
+        return new ReadEntryResult(output == null ? null : output.toByteArray(), entryBytes);
+    }
+
+    private IOException entrySizeLimitException() {
+        return new IOException("JAR entry exceeds maximum expanded size of "
+                + resourceLimits.maxEntryUncompressedBytes() + " bytes");
+    }
+
+    private IOException totalSizeLimitException() {
+        return new IOException("Plugin JAR exceeds maximum expanded size of "
+                + resourceLimits.maxTotalUncompressedBytes() + " bytes");
     }
 
     private byte[] transformClass(String entryName, byte[] classBytes) {
@@ -334,6 +382,25 @@ public final class PluginPatcher {
         return transformationFailures.stream()
                 .sorted(java.util.Comparator.comparing(TransformationFailure::className))
                 .toList();
+    }
+
+    static record JarResourceLimits(
+            long maxInputBytes,
+            long maxEntryUncompressedBytes,
+            long maxTotalUncompressedBytes,
+            int maxEntryCount) {
+
+        JarResourceLimits {
+            if (maxInputBytes <= 0
+                    || maxEntryUncompressedBytes <= 0
+                    || maxTotalUncompressedBytes <= 0
+                    || maxEntryCount <= 0) {
+                throw new IllegalArgumentException("JAR resource limits must be positive");
+            }
+        }
+    }
+
+    private record ReadEntryResult(byte[] content, long uncompressedBytes) {
     }
 
     private static final class SafeClassWriter extends ClassWriter {

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/PluginPatcher.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/PluginPatcher.java
@@ -31,9 +31,10 @@ import java.util.concurrent.ForkJoinTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.jar.JarEntry;
-import java.util.jar.JarInputStream;
 import java.util.jar.JarOutputStream;
 import java.util.zip.Deflater;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 /**
  * JAR 全体のパッチ処理を統括するオーケストレーター。
@@ -157,9 +158,9 @@ public final class PluginPatcher {
         List<PreparedEntry> entries = new ArrayList<>();
         long totalUncompressedBytes = 0;
         int entryCount = 0;
-        try (JarInputStream input = new JarInputStream(Files.newInputStream(jarPath))) {
-            JarEntry entry;
-            while ((entry = input.getNextJarEntry()) != null) {
+        try (ZipInputStream input = new ZipInputStream(Files.newInputStream(jarPath))) {
+            ZipEntry entry;
+            while ((entry = input.getNextEntry()) != null) {
                 entryCount++;
                 if (entryCount > resourceLimits.maxEntryCount()) {
                     throw new IOException("Plugin JAR exceeds maximum entry count of "
@@ -202,7 +203,7 @@ public final class PluginPatcher {
 
     private ReadEntryResult readEntryBounded(
             InputStream input,
-            JarEntry entry,
+            ZipEntry entry,
             long remainingTotalBytes,
             boolean retainContent) throws IOException {
         long declaredSize = entry.getSize();

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/PluginPatcher.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/PluginPatcher.java
@@ -14,6 +14,7 @@ import org.objectweb.asm.tree.ClassNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -44,6 +45,10 @@ public final class PluginPatcher {
 
     private static final Logger log = LoggerFactory.getLogger(PluginPatcher.class);
     private static final int ASM_API = Opcodes.ASM9;
+    private static final long MAX_INPUT_BYTES = 256L * 1024 * 1024;
+    private static final long MAX_ENTRY_UNCOMPRESSED_BYTES = 64L * 1024 * 1024;
+    private static final long MAX_TOTAL_UNCOMPRESSED_BYTES = 512L * 1024 * 1024;
+    private static final int MAX_ENTRY_COUNT = 100_000;
     private static final byte[] BUKKIT_CONSTANT_POOL_MARKER =
             "org/bukkit/".getBytes(StandardCharsets.US_ASCII);
     private static final String[] RUNTIME_CLASSES = {
@@ -95,6 +100,10 @@ public final class PluginPatcher {
             log.warn("Skipping already-patched JAR: {}", fileName);
             return jarPath;
         }
+        long inputSize = Files.size(jarPath);
+        if (inputSize > MAX_INPUT_BYTES) {
+            throw new IOException("Plugin JAR exceeds maximum input size of " + MAX_INPUT_BYTES + " bytes: " + fileName);
+        }
 
         long startedAt = System.nanoTime();
         patchedClassCount.set(0);
@@ -134,6 +143,8 @@ public final class PluginPatcher {
 
     private List<PreparedEntry> readAndPrepareEntries(Path jarPath) throws IOException {
         List<PreparedEntry> entries = new ArrayList<>();
+        long totalUncompressedBytes = 0;
+        int entryCount = 0;
         try (JarInputStream input = new JarInputStream(Files.newInputStream(jarPath))) {
             JarEntry entry;
             while ((entry = input.getNextJarEntry()) != null) {
@@ -141,8 +152,17 @@ public final class PluginPatcher {
                 if (entry.isDirectory() || isSignatureFile(name)) {
                     continue;
                 }
+                entryCount++;
+                if (entryCount > MAX_ENTRY_COUNT) {
+                    throw new IOException("Plugin JAR exceeds maximum entry count of " + MAX_ENTRY_COUNT);
+                }
 
-                byte[] content = input.readAllBytes();
+                byte[] content = readEntryBounded(input, name);
+                totalUncompressedBytes += content.length;
+                if (totalUncompressedBytes > MAX_TOTAL_UNCOMPRESSED_BYTES) {
+                    throw new IOException("Plugin JAR exceeds maximum expanded size of "
+                            + MAX_TOTAL_UNCOMPRESSED_BYTES + " bytes");
+                }
                 if ("plugin.yml".equals(name)) {
                     entries.add(PreparedEntry.direct(name, modifyPluginYml(content)));
                 } else if (name.endsWith(".class")) {
@@ -161,12 +181,27 @@ public final class PluginPatcher {
         return entries;
     }
 
+    private static byte[] readEntryBounded(InputStream input, String entryName) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[8192];
+        long entryBytes = 0;
+        int read;
+        while ((read = input.read(buffer)) != -1) {
+            entryBytes += read;
+            if (entryBytes > MAX_ENTRY_UNCOMPRESSED_BYTES) {
+                throw new IOException("JAR entry exceeds maximum expanded size of "
+                        + MAX_ENTRY_UNCOMPRESSED_BYTES + " bytes: " + entryName);
+            }
+            output.write(buffer, 0, read);
+        }
+        return output.toByteArray();
+    }
+
     private byte[] transformClass(String entryName, byte[] classBytes) {
         String className = entryName.substring(0, entryName.length() - ".class".length())
                 .replace('/', '.');
 
         try {
-            // Most library classes do not reference Bukkit at all. Avoid constructing ASM visitors for them.
             if (!containsBytes(classBytes, BUKKIT_CONSTANT_POOL_MARKER) || !needsPatching(classBytes)) {
                 skippedClassCount.incrementAndGet();
                 if (verbose) {
@@ -301,12 +336,6 @@ public final class PluginPatcher {
                 .toList();
     }
 
-    /**
-     * ASM normally loads referenced classes while computing stack map frames. Plugin dependencies
-     * such as Bukkit/Paper are intentionally absent from the CLI and browser runtime, so fall back
-     * to Object when an external type cannot be resolved. Resolvable JDK/application types still use
-     * ASM's normal hierarchy calculation.
-     */
     private static final class SafeClassWriter extends ClassWriter {
 
         private SafeClassWriter(int flags) {

--- a/folia-phantom/folia-phantom-core/src/test/java/com/patch/foliaphantom/patcher/PluginPatcherResourceLimitTest.java
+++ b/folia-phantom/folia-phantom-core/src/test/java/com/patch/foliaphantom/patcher/PluginPatcherResourceLimitTest.java
@@ -1,52 +1,150 @@
 package com.patch.foliaphantom.patcher;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
-class PluginPatcherResourceLimitTest {
+public class PluginPatcherResourceLimitTest {
 
-    @TempDir
-    Path tempDir;
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Test
-    void rejectsHighlyCompressedEntryThatExpandsPastLimit() throws Exception {
-        Path input = tempDir.resolve("zip-bomb.jar");
-        byte[] block = new byte[1024 * 1024];
-        try (OutputStream file = Files.newOutputStream(input);
-             JarOutputStream jar = new JarOutputStream(file)) {
-            jar.putNextEntry(new JarEntry("payload.bin"));
-            for (int i = 0; i < 65; i++) {
-                jar.write(block);
-            }
-            jar.closeEntry();
-        }
+    public void rejectsHighlyCompressedEntryThatExpandsPastPerEntryLimit() throws Exception {
+        Path input = createJarWithRepeatedBytes("zip-bomb.jar", "payload.bin", 4096);
+        PluginPatcher patcher = patcherWithLimits(1_000_000, 1024, 8192, 10);
 
-        PluginPatcher patcher = new PluginPatcher(tempDir.resolve("out"), false, false);
         IOException exception = assertThrows(IOException.class, () -> patcher.patchPlugin(input));
-        assertTrue(exception.getMessage().contains("maximum expanded size"));
+
+        assertTrue(exception.getMessage().contains("JAR entry exceeds maximum expanded size"));
     }
 
     @Test
-    void ordinaryPluginJarStillPatches() throws Exception {
-        Path input = tempDir.resolve("ordinary.jar");
+    public void rejectsCombinedExpansionPastTotalLimit() throws Exception {
+        Path input = temporaryFolder.getRoot().toPath().resolve("combined.jar");
         try (OutputStream file = Files.newOutputStream(input);
              JarOutputStream jar = new JarOutputStream(file)) {
-            jar.putNextEntry(new JarEntry("plugin.yml"));
-            jar.write("name: Ordinary\nversion: 1.0\nmain: example.Main\n".getBytes());
-            jar.closeEntry();
+            writeEntry(jar, "first.bin", new byte[700]);
+            writeEntry(jar, "second.bin", new byte[700]);
         }
+        PluginPatcher patcher = patcherWithLimits(1_000_000, 1024, 1200, 10);
 
-        Path output = new PluginPatcher(tempDir.resolve("out"), false, false).patchPlugin(input);
+        IOException exception = assertThrows(IOException.class, () -> patcher.patchPlugin(input));
+
+        assertTrue(exception.getMessage().contains("Plugin JAR exceeds maximum expanded size"));
+    }
+
+    @Test
+    public void appliesExpansionLimitsToSignatureEntriesThatWillBeDiscarded() throws Exception {
+        Path input = createJarWithRepeatedBytes("signature-bomb.jar", "META-INF/ATTACK.SF", 4096);
+        PluginPatcher patcher = patcherWithLimits(1_000_000, 1024, 8192, 10);
+
+        IOException exception = assertThrows(IOException.class, () -> patcher.patchPlugin(input));
+
+        assertTrue(exception.getMessage().contains("JAR entry exceeds maximum expanded size"));
+    }
+
+    @Test
+    public void countsDiscardedEntriesTowardEntryLimit() throws Exception {
+        Path input = temporaryFolder.getRoot().toPath().resolve("many-entries.jar");
+        try (OutputStream file = Files.newOutputStream(input);
+             JarOutputStream jar = new JarOutputStream(file)) {
+            jar.putNextEntry(new JarEntry("directory/"));
+            jar.closeEntry();
+            writeEntry(jar, "META-INF/IGNORED.SF", new byte[] {1});
+            writeEntry(jar, "plugin.yml", pluginYml());
+        }
+        PluginPatcher patcher = patcherWithLimits(1_000_000, 1024, 8192, 2);
+
+        IOException exception = assertThrows(IOException.class, () -> patcher.patchPlugin(input));
+
+        assertTrue(exception.getMessage().contains("maximum entry count"));
+    }
+
+    @Test
+    public void rejectsCompressedInputPastFileSizeLimit() throws Exception {
+        Path input = temporaryFolder.getRoot().toPath().resolve("input-too-large.jar");
+        try (OutputStream file = Files.newOutputStream(input);
+             JarOutputStream jar = new JarOutputStream(file)) {
+            writeEntry(jar, "plugin.yml", pluginYml());
+        }
+        PluginPatcher patcher = patcherWithLimits(32, 1024, 8192, 10);
+
+        IOException exception = assertThrows(IOException.class, () -> patcher.patchPlugin(input));
+
+        assertTrue(exception.getMessage().contains("maximum input size"));
+    }
+
+    @Test
+    public void ordinaryPluginJarStillPatchesAndGetsFoliaMetadata() throws Exception {
+        Path input = temporaryFolder.getRoot().toPath().resolve("ordinary.jar");
+        try (OutputStream file = Files.newOutputStream(input);
+             JarOutputStream jar = new JarOutputStream(file)) {
+            writeEntry(jar, "plugin.yml", pluginYml());
+        }
+        PluginPatcher patcher = patcherWithLimits(4096, 2048, 4096, 10);
+
+        Path output = patcher.patchPlugin(input);
+
         assertTrue(Files.isRegularFile(output));
+        try (JarFile jar = new JarFile(output.toFile())) {
+            String pluginYml = new String(
+                    jar.getInputStream(jar.getJarEntry("plugin.yml")).readAllBytes(),
+                    StandardCharsets.UTF_8);
+            assertTrue(pluginYml.contains("folia-supported: true"));
+        }
+        assertEquals(0, patcher.getFailedClassCount());
+    }
+
+    private PluginPatcher patcherWithLimits(
+            long maxInputBytes,
+            long maxEntryBytes,
+            long maxTotalBytes,
+            int maxEntryCount) {
+        PluginPatcher.JarResourceLimits limits = new PluginPatcher.JarResourceLimits(
+                maxInputBytes,
+                maxEntryBytes,
+                maxTotalBytes,
+                maxEntryCount);
+        return new PluginPatcher(
+                temporaryFolder.getRoot().toPath().resolve("out"),
+                false,
+                false,
+                limits);
+    }
+
+    private Path createJarWithRepeatedBytes(String fileName, String entryName, int bytes)
+            throws IOException {
+        Path input = temporaryFolder.getRoot().toPath().resolve(fileName);
+        try (OutputStream file = Files.newOutputStream(input);
+             JarOutputStream jar = new JarOutputStream(file)) {
+            writeEntry(jar, entryName, new byte[bytes]);
+        }
+        return input;
+    }
+
+    private static void writeEntry(JarOutputStream jar, String name, byte[] content)
+            throws IOException {
+        jar.putNextEntry(new JarEntry(name));
+        jar.write(content);
+        jar.closeEntry();
+    }
+
+    private static byte[] pluginYml() {
+        return "name: Ordinary\nversion: 1.0\nmain: example.Main\n"
+                .getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/folia-phantom/folia-phantom-core/src/test/java/com/patch/foliaphantom/patcher/PluginPatcherResourceLimitTest.java
+++ b/folia-phantom/folia-phantom-core/src/test/java/com/patch/foliaphantom/patcher/PluginPatcherResourceLimitTest.java
@@ -1,0 +1,52 @@
+package com.patch.foliaphantom.patcher;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PluginPatcherResourceLimitTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void rejectsHighlyCompressedEntryThatExpandsPastLimit() throws Exception {
+        Path input = tempDir.resolve("zip-bomb.jar");
+        byte[] block = new byte[1024 * 1024];
+        try (OutputStream file = Files.newOutputStream(input);
+             JarOutputStream jar = new JarOutputStream(file)) {
+            jar.putNextEntry(new JarEntry("payload.bin"));
+            for (int i = 0; i < 65; i++) {
+                jar.write(block);
+            }
+            jar.closeEntry();
+        }
+
+        PluginPatcher patcher = new PluginPatcher(tempDir.resolve("out"), false, false);
+        IOException exception = assertThrows(IOException.class, () -> patcher.patchPlugin(input));
+        assertTrue(exception.getMessage().contains("maximum expanded size"));
+    }
+
+    @Test
+    void ordinaryPluginJarStillPatches() throws Exception {
+        Path input = tempDir.resolve("ordinary.jar");
+        try (OutputStream file = Files.newOutputStream(input);
+             JarOutputStream jar = new JarOutputStream(file)) {
+            jar.putNextEntry(new JarEntry("plugin.yml"));
+            jar.write("name: Ordinary\nversion: 1.0\nmain: example.Main\n".getBytes());
+            jar.closeEntry();
+        }
+
+        Path output = new PluginPatcher(tempDir.resolve("out"), false, false).patchPlugin(input);
+        assertTrue(Files.isRegularFile(output));
+    }
+}

--- a/folia-phantom/folia-phantom-core/src/test/java/com/patch/foliaphantom/patcher/PluginPatcherResourceLimitTest.java
+++ b/folia-phantom/folia-phantom-core/src/test/java/com/patch/foliaphantom/patcher/PluginPatcherResourceLimitTest.java
@@ -33,6 +33,19 @@ public class PluginPatcherResourceLimitTest {
     }
 
     @Test
+    public void rejectsManifestThatExpandsPastPerEntryLimit() throws Exception {
+        Path input = createJarWithRepeatedBytes(
+                "manifest-bomb.jar",
+                "META-INF/MANIFEST.MF",
+                4096);
+        PluginPatcher patcher = patcherWithLimits(1_000_000, 1024, 8192, 10);
+
+        IOException exception = assertThrows(IOException.class, () -> patcher.patchPlugin(input));
+
+        assertTrue(exception.getMessage().contains("JAR entry exceeds maximum expanded size"));
+    }
+
+    @Test
     public void rejectsCombinedExpansionPastTotalLimit() throws Exception {
         Path input = temporaryFolder.getRoot().toPath().resolve("combined.jar");
         try (OutputStream file = Files.newOutputStream(input);


### PR DESCRIPTION
## Problem

pasta can already automate transformation through its CLI, but plugin repositories have to duplicate Java/Maven/CLI setup in every GitHub Actions workflow.

## Peperoncino milestone

This PR introduces the first **Peperoncino** update: first-class GitHub Actions integration.

### Changes

- add a root `action.yml` composite action;
- accept a plugin JAR or directory through the `input` parameter;
- build and run the pasta CLI from the exact action revision;
- expose `output_directory` and `patched_count` outputs;
- fail clearly when the input is missing or no patched artifact is produced;
- add an end-to-end smoke workflow that patches a generated fixture JAR and verifies `folia-supported: true`;
- use `actions/setup-java@v5` / `actions/checkout@v5` for the new Peperoncino path;
- document usage, execution model, limitations, and future analyzer direction in `PEPERONCINO.md` and the README.

### Security hardening

Codex Security review identified an archive resource-exhaustion path because plugin JARs are untrusted and entry contents could previously expand without a complete archive-wide bound.

The patcher now enforces the resource boundary in the shared core path used by the CLI, GUI, web bridge, server plugin, and Peperoncino:

- compressed input JAR: 256 MiB maximum;
- expanded size of one entry: 64 MiB maximum;
- total expanded archive size: 512 MiB maximum;
- archive entry count: 100,000 maximum;
- limits apply to all entries, including directories, signatures that are later discarded, and `META-INF/MANIFEST.MF`;
- input parsing uses `ZipInputStream` so the manifest cannot be parsed outside the bounded entry loop.

Regression tests use deliberately small injected limits to cover compressed-entry expansion, manifest expansion, discarded signature entries, aggregate expansion, entry count, compressed input size, and a legitimate plugin JAR without allocating large fixtures.

## Example

```yaml
- name: Patch for Folia
  id: pasta
  uses: MARVserver/pasta@develop
  with:
    input: target/my-plugin.jar
    output: build/pasta
```

## Safety / compatibility

This deliberately reuses the existing CLI rather than changing transformer semantics. A green Action run means transformation succeeded; it does **not** certify arbitrary plugin state as thread-safe under Folia.

## Verification

GitHub-hosted checks pass on the current head:

- ✅ Peperoncino Action Smoke Test — fixture JAR patched and Folia metadata verified
- ✅ Verify (Java 21) — full Maven reactor verification including JAR resource-limit regression tests
- ✅ dependency-review
- ✅ CodeQL

The smoke test also caught and drove a portability fix in the initial Maven cache-path configuration before this PR was marked ready.