### PR TITLE
perf: harden and benchmark browser patching

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,8 @@ name: Pages
 on:
   push:
     branches: [develop]
+  pull_request:
+    branches: [develop]
   workflow_dispatch:
 
 permissions:
@@ -11,7 +13,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  group: pages-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -36,15 +38,46 @@ jobs:
       - name: Assemble static site
         run: cp folia-phantom/folia-phantom-web/target/pasta-web.jar web/pasta-web.jar
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install browser test dependencies
+        working-directory: web
+        run: npm install --no-package-lock --no-audit --no-fund
+
+      - name: Install Chromium
+        working-directory: web
+        run: npx playwright install --with-deps chromium
+
+      - name: Run browser end-to-end tests
+        working-directory: web
+        run: npm run test:e2e
+
+      - name: Upload browser test diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pasta-web-e2e-${{ github.sha }}
+          path: |
+            web/playwright-report/
+            web/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Configure Pages
+        if: github.event_name != 'pull_request'
         uses: actions/configure-pages@v5
 
       - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v4
         with:
           path: web
 
   deploy:
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ target/
 .idea/
 .vscode/
 dependency-reduced-pom.xml
+web/node_modules/
+web/playwright-report/
+web/test-results/

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/PluginPatcher.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/PluginPatcher.java
@@ -129,6 +129,31 @@ public final class PluginPatcher {
         int workers = parallel ? forkJoinPool.getParallelism() : 1;
         log.info("Patching plugin: {} with {} worker(s)", fileName, workers);
 
+        try {
+            if (parallel) {
+                writePreparedEntries(jarPath, outputPath);
+            } else {
+                writeSequentialEntries(jarPath, outputPath);
+            }
+        } catch (RuntimeException exception) {
+            Files.deleteIfExists(outputPath);
+            Throwable cause = exception.getCause();
+            if (cause instanceof IOException ioException) {
+                throw ioException;
+            }
+            throw exception;
+        } catch (IOException exception) {
+            Files.deleteIfExists(outputPath);
+            throw exception;
+        }
+
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
+        log.info("Patch complete for: {} (patched: {}, skipped: {}, unchanged after errors: {}, elapsed: {} ms)",
+                fileName, patchedClassCount.get(), skippedClassCount.get(), failedClassCount.get(), elapsedMs);
+        return outputPath;
+    }
+
+    private void writePreparedEntries(Path jarPath, Path outputPath) throws IOException {
         List<PreparedEntry> prepared = readAndPrepareEntries(jarPath);
 
         try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(outputPath))) {
@@ -139,23 +164,44 @@ public final class PluginPatcher {
                 writtenNames.add(entry.name());
             }
             bundleRuntimeClasses(output, writtenNames);
-        } catch (RuntimeException exception) {
-            Files.deleteIfExists(outputPath);
-            Throwable cause = exception.getCause();
-            if (cause instanceof IOException ioException) {
-                throw ioException;
-            }
-            throw exception;
         }
+    }
 
-        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
-        log.info("Patch complete for: {} (patched: {}, skipped: {}, unchanged after errors: {}, elapsed: {} ms)",
-                fileName, patchedClassCount.get(), skippedClassCount.get(), failedClassCount.get(), elapsedMs);
-        return outputPath;
+    /**
+     * Browser mode disables parallel ASM work. Stream each retained entry directly to the output
+     * so expanded JAR contents are not all retained in Java memory at once.
+     */
+    private void writeSequentialEntries(Path jarPath, Path outputPath) throws IOException {
+        try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(outputPath))) {
+            output.setLevel(Deflater.BEST_SPEED);
+            Set<String> writtenNames = new HashSet<>();
+
+            readRetainedEntries(jarPath, (name, content) -> {
+                byte[] preparedContent = prepareSequentialContent(name, content);
+                addJarEntry(output, name, preparedContent);
+                writtenNames.add(name);
+            });
+
+            bundleRuntimeClasses(output, writtenNames);
+        }
     }
 
     private List<PreparedEntry> readAndPrepareEntries(Path jarPath) throws IOException {
         List<PreparedEntry> entries = new ArrayList<>();
+        readRetainedEntries(jarPath, (name, content) -> {
+            if (isPluginDescriptor(name)) {
+                entries.add(PreparedEntry.direct(name, modifyPluginDescriptor(content)));
+            } else if (name.endsWith(".class")) {
+                ForkJoinTask<byte[]> task = forkJoinPool.submit(() -> transformClass(name, content));
+                entries.add(PreparedEntry.async(name, task));
+            } else {
+                entries.add(PreparedEntry.direct(name, content));
+            }
+        });
+        return entries;
+    }
+
+    private void readRetainedEntries(Path jarPath, RetainedEntryConsumer consumer) throws IOException {
         long totalUncompressedBytes = 0;
         int entryCount = 0;
         try (ZipInputStream input = new ZipInputStream(Files.newInputStream(jarPath))) {
@@ -178,27 +224,21 @@ public final class PluginPatcher {
                         retainContent);
                 totalUncompressedBytes += readResult.uncompressedBytes();
 
-                if (!retainContent) {
-                    continue;
-                }
-
-                byte[] content = readResult.content();
-                if ("plugin.yml".equals(name)) {
-                    entries.add(PreparedEntry.direct(name, modifyPluginYml(content)));
-                } else if (name.endsWith(".class")) {
-                    if (parallel) {
-                        ForkJoinTask<byte[]> task = forkJoinPool.submit(
-                                () -> transformClass(name, content));
-                        entries.add(PreparedEntry.async(name, task));
-                    } else {
-                        entries.add(PreparedEntry.direct(name, transformClass(name, content)));
-                    }
-                } else {
-                    entries.add(PreparedEntry.direct(name, content));
+                if (retainContent) {
+                    consumer.accept(name, readResult.content());
                 }
             }
         }
-        return entries;
+    }
+
+    private byte[] prepareSequentialContent(String name, byte[] content) {
+        if (isPluginDescriptor(name)) {
+            return modifyPluginDescriptor(content);
+        }
+        if (name.endsWith(".class")) {
+            return transformClass(name, content);
+        }
+        return content;
     }
 
     private ReadEntryResult readEntryBounded(
@@ -314,7 +354,11 @@ public final class PluginPatcher {
         return false;
     }
 
-    private byte[] modifyPluginYml(byte[] bytes) {
+    private static boolean isPluginDescriptor(String entryName) {
+        return "plugin.yml".equals(entryName) || "paper-plugin.yml".equals(entryName);
+    }
+
+    private byte[] modifyPluginDescriptor(byte[] bytes) {
         String content = new String(bytes, StandardCharsets.UTF_8);
         if (content.contains("folia-supported: true")) {
             return bytes;
@@ -402,6 +446,11 @@ public final class PluginPatcher {
     }
 
     private record ReadEntryResult(byte[] content, long uncompressedBytes) {
+    }
+
+    @FunctionalInterface
+    private interface RetainedEntryConsumer {
+        void accept(String name, byte[] content) throws IOException;
     }
 
     private static final class SafeClassWriter extends ClassWriter {

--- a/folia-phantom/folia-phantom-core/src/test/java/com/patch/foliaphantom/patcher/PluginPatcherResourceLimitTest.java
+++ b/folia-phantom/folia-phantom-core/src/test/java/com/patch/foliaphantom/patcher/PluginPatcherResourceLimitTest.java
@@ -14,6 +14,7 @@ import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -103,23 +104,54 @@ public class PluginPatcherResourceLimitTest {
 
     @Test
     public void ordinaryPluginJarStillPatchesAndGetsFoliaMetadata() throws Exception {
-        Path input = temporaryFolder.getRoot().toPath().resolve("ordinary.jar");
-        try (OutputStream file = Files.newOutputStream(input);
-             JarOutputStream jar = new JarOutputStream(file)) {
-            writeEntry(jar, "plugin.yml", pluginYml());
-        }
+        Path input = createDescriptorJar("ordinary.jar", "plugin.yml", pluginYml());
         PluginPatcher patcher = patcherWithLimits(4096, 2048, 4096, 10);
 
         Path output = patcher.patchPlugin(input);
 
         assertTrue(Files.isRegularFile(output));
-        try (JarFile jar = new JarFile(output.toFile())) {
-            String pluginYml = new String(
-                    jar.getInputStream(jar.getJarEntry("plugin.yml")).readAllBytes(),
-                    StandardCharsets.UTF_8);
-            assertTrue(pluginYml.contains("folia-supported: true"));
-        }
+        assertDescriptorHasFoliaMetadata(output, "plugin.yml");
         assertEquals(0, patcher.getFailedClassCount());
+    }
+
+    @Test
+    public void paperPluginDescriptorGetsFoliaMetadataInSequentialMode() throws Exception {
+        Path input = createDescriptorJar("paper.jar", "paper-plugin.yml", paperPluginYml());
+        PluginPatcher patcher = patcherWithLimits(4096, 2048, 4096, 10);
+
+        Path output = patcher.patchPlugin(input);
+
+        assertDescriptorHasFoliaMetadata(output, "paper-plugin.yml");
+        assertEquals(0, patcher.getFailedClassCount());
+    }
+
+    @Test
+    public void paperPluginDescriptorGetsFoliaMetadataInParallelMode() throws Exception {
+        Path input = createDescriptorJar("paper-parallel.jar", "paper-plugin.yml", paperPluginYml());
+        PluginPatcher patcher = patcherWithLimits(4096, 2048, 4096, 10, true);
+
+        Path output = patcher.patchPlugin(input);
+
+        assertDescriptorHasFoliaMetadata(output, "paper-plugin.yml");
+        assertEquals(0, patcher.getFailedClassCount());
+    }
+
+    @Test
+    public void existingFalseFoliaMetadataIsReplacedForPaperPlugins() throws Exception {
+        byte[] descriptor = ("name: PaperPlugin\n"
+                + "version: 1.0\n"
+                + "main: example.Main\n"
+                + "folia-supported: false\n").getBytes(StandardCharsets.UTF_8);
+        Path input = createDescriptorJar("paper-false.jar", "paper-plugin.yml", descriptor);
+        PluginPatcher patcher = patcherWithLimits(4096, 2048, 4096, 10);
+
+        Path output = patcher.patchPlugin(input);
+
+        assertDescriptorHasFoliaMetadata(output, "paper-plugin.yml");
+        try (JarFile jar = new JarFile(output.toFile())) {
+            String paperPluginYml = readEntry(jar, "paper-plugin.yml");
+            assertFalse(paperPluginYml.contains("folia-supported: false"));
+        }
     }
 
     private PluginPatcher patcherWithLimits(
@@ -127,6 +159,20 @@ public class PluginPatcherResourceLimitTest {
             long maxEntryBytes,
             long maxTotalBytes,
             int maxEntryCount) {
+        return patcherWithLimits(
+                maxInputBytes,
+                maxEntryBytes,
+                maxTotalBytes,
+                maxEntryCount,
+                false);
+    }
+
+    private PluginPatcher patcherWithLimits(
+            long maxInputBytes,
+            long maxEntryBytes,
+            long maxTotalBytes,
+            int maxEntryCount,
+            boolean parallel) {
         PluginPatcher.JarResourceLimits limits = new PluginPatcher.JarResourceLimits(
                 maxInputBytes,
                 maxEntryBytes,
@@ -135,7 +181,7 @@ public class PluginPatcherResourceLimitTest {
         return new PluginPatcher(
                 temporaryFolder.getRoot().toPath().resolve("out"),
                 false,
-                false,
+                parallel,
                 limits);
     }
 
@@ -149,6 +195,30 @@ public class PluginPatcherResourceLimitTest {
         return input;
     }
 
+    private Path createDescriptorJar(String fileName, String entryName, byte[] descriptor)
+            throws IOException {
+        Path input = temporaryFolder.getRoot().toPath().resolve(fileName);
+        try (OutputStream file = Files.newOutputStream(input);
+             JarOutputStream jar = new JarOutputStream(file)) {
+            writeEntry(jar, entryName, descriptor);
+        }
+        return input;
+    }
+
+    private static void assertDescriptorHasFoliaMetadata(Path output, String entryName)
+            throws IOException {
+        try (JarFile jar = new JarFile(output.toFile())) {
+            String descriptor = readEntry(jar, entryName);
+            assertTrue(descriptor.contains("folia-supported: true"));
+        }
+    }
+
+    private static String readEntry(JarFile jar, String entryName) throws IOException {
+        return new String(
+                jar.getInputStream(jar.getJarEntry(entryName)).readAllBytes(),
+                StandardCharsets.UTF_8);
+    }
+
     private static void writeEntry(JarOutputStream jar, String name, byte[] content)
             throws IOException {
         jar.putNextEntry(new JarEntry(name));
@@ -158,6 +228,11 @@ public class PluginPatcherResourceLimitTest {
 
     private static byte[] pluginYml() {
         return "name: Ordinary\nversion: 1.0\nmain: example.Main\n"
+                .getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static byte[] paperPluginYml() {
+        return "name: PaperPlugin\nversion: 1.0\nmain: example.Main\napi-version: '1.21'\n"
                 .getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,54 @@
+# pasta browser frontend
+
+The static `web/` frontend runs the same Java patcher core through CheerpJ. Plugin JAR bytes stay in the browser; there is no upload or conversion backend.
+
+## Runtime behavior
+
+When one or more patchable JARs are selected, the page starts warming the CheerpJ Java runtime immediately. The Patch button reuses that same initialization promise, so selection time overlaps the cold-start cost instead of waiting to initialize Java only after the user clicks.
+
+Browser mode constructs `PluginPatcher` with parallel transformation disabled. In this mode, the core patcher reads one retained JAR entry, transforms it, writes it to the output JAR, and releases the entry before reading the next one. Desktop and CLI paths keep the existing parallel preparation path.
+
+Both `plugin.yml` and `paper-plugin.yml` receive `folia-supported: true`. Transformation success still does not certify arbitrary plugin state as Folia thread-safe.
+
+## Local performance metrics
+
+The UI records, using `performance.now()`:
+
+- CheerpJ runtime initialization time;
+- end-to-end processing time for each selected JAR;
+- input JAR byte size.
+
+These metrics are displayed locally and included in `pasta-report.csv` as `runtime_init_ms`, `patch_ms`, and `input_bytes`. They are not sent anywhere.
+
+## Browser end-to-end test
+
+The Playwright test exercises the real static UI with Chromium and CheerpJ:
+
+1. drag-and-drop selection;
+2. clear/reset behavior;
+3. `paper-plugin.yml` transformation and downloaded JAR inspection;
+4. a deliberately malformed class that must produce a partial result rather than aborting the JAR;
+5. locally generated timing columns in the CSV report.
+
+Prerequisites:
+
+- JDK 21, including the `jar` command;
+- Node.js 22+;
+- Python 3;
+- `unzip`.
+
+Build and run:
+
+```bash
+cd folia-phantom
+mvn --batch-mode --no-transfer-progress -pl folia-phantom-web -am package
+cd ..
+cp folia-phantom/folia-phantom-web/target/pasta-web.jar web/pasta-web.jar
+
+cd web
+npm install --no-package-lock --no-audit --no-fund
+npx playwright install chromium
+npm run test:e2e
+```
+
+The GitHub Pages workflow runs the same Chromium E2E test on pull requests targeting `develop` and gates deployment on `develop` pushes.

--- a/web/app.js
+++ b/web/app.js
@@ -14,6 +14,8 @@ const resultsContainer = document.getElementById("results");
 const reportDownload = document.getElementById("report-download");
 
 let patcherPromise;
+let runtimeInitMs = null;
+let runtimeState = "idle";
 let objectUrls = [];
 let selectedFileList = [];
 let isBusy = false;
@@ -59,7 +61,7 @@ clearButton.addEventListener("click", () => {
     selectedFileList = [];
     clearReport();
     renderSelection();
-    status.textContent = "Select one or more .jar files.";
+    updateSelectionStatus();
 });
 
 patchButton.addEventListener("click", async () => {
@@ -77,21 +79,33 @@ patchButton.addEventListener("click", async () => {
     let currentPatchable = 0;
 
     try {
-        status.textContent = "Loading Java runtime…";
+        status.textContent = runtimeState === "ready"
+            ? "Java runtime ready. Starting patch…"
+            : "Loading Java runtime…";
         const patcher = await getPatcher();
 
         for (let index = 0; index < files.length; index++) {
             const file = files[index];
 
             if (!isJar(file)) {
-                results.push(emptyResult(file.name, "skipped", "Not a .jar file."));
+                results.push(emptyResult(
+                        file.name,
+                        "skipped",
+                        "Not a .jar file.",
+                        file.size,
+                        0));
                 progress.value = index + 1;
                 renderReport(results, files.length);
                 continue;
             }
 
             if (isAlreadyPatched(file)) {
-                results.push(emptyResult(file.name, "skipped", "Already patched."));
+                results.push(emptyResult(
+                        file.name,
+                        "skipped",
+                        "Already patched.",
+                        file.size,
+                        0));
                 progress.value = index + 1;
                 renderReport(results, files.length);
                 continue;
@@ -103,19 +117,24 @@ patchButton.addEventListener("click", async () => {
             const safeName = `input-${index}-${sanitizeFileName(file.name)}`;
             const inputPath = `/str/${safeName}`;
             const outputPath = `/files/patched-${safeName}`;
+            const patchStartedAt = performance.now();
 
             try {
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                cheerpOSAddStringFile(inputPath, bytes);
+                cheerpOSAddStringFile(
+                        inputPath,
+                        new Uint8Array(await file.arrayBuffer()));
 
                 const rawReport = await patcher.patch(inputPath);
                 const parsed = parsePatchReport(String(rawReport));
                 const blob = await cjFileBlob(outputPath);
                 const resultUrl = URL.createObjectURL(blob);
                 objectUrls.push(resultUrl);
+                const patchMs = performance.now() - patchStartedAt;
 
                 results.push({
                     file: file.name,
+                    sizeBytes: file.size,
+                    patchMs,
                     status: parsed.failed > 0 ? "partial" : "success",
                     patched: parsed.patched,
                     skipped: parsed.skipped,
@@ -136,7 +155,12 @@ patchButton.addEventListener("click", async () => {
                 }
             } catch (error) {
                 console.error(error);
-                results.push(emptyResult(file.name, "failed", await errorMessage(error)));
+                results.push(emptyResult(
+                        file.name,
+                        "failed",
+                        await errorMessage(error),
+                        file.size,
+                        performance.now() - patchStartedAt));
             } finally {
                 cheerpOSRemoveStringFile(inputPath);
             }
@@ -146,7 +170,13 @@ patchButton.addEventListener("click", async () => {
         }
 
         const counts = resultCounts(results);
-        status.textContent = `Done. ${counts.success} succeeded, ${counts.partial} partial, ${counts.failed} failed, ${counts.skipped} skipped.`;
+        const totalPatchMs = results.reduce(
+                (sum, result) => sum + (result.patchMs || 0),
+                0);
+        const timing = totalPatchMs > 0
+            ? ` Processing time ${formatDuration(totalPatchMs)}.`
+            : "";
+        status.textContent = `Done. ${counts.success} succeeded, ${counts.partial} partial, ${counts.failed} failed, ${counts.skipped} skipped.${timing}`;
         updateReportDownload(results);
 
         const downloadable = results.filter(hasOutput);
@@ -167,17 +197,57 @@ function setSelectedFiles(files) {
     selectedFileList = uniqueFiles(files);
     clearReport();
     renderSelection();
+    updateSelectionStatus();
 
+    if (selectedFileList.some(isPatchableJar)) {
+        void warmPatcher();
+    }
+}
+
+async function warmPatcher() {
+    const warmPromise = getPatcher();
+    if (!isBusy) updateSelectionStatus();
+
+    try {
+        await warmPromise;
+    } catch (error) {
+        console.warn("Could not preload Java runtime", error);
+    }
+
+    if (!isBusy) updateSelectionStatus();
+}
+
+function selectionStatusBase() {
     const patchable = selectedFileList.filter(isPatchableJar);
     const ignored = selectedFileList.length - patchable.length;
 
     if (selectedFileList.length === 0) {
-        status.textContent = "Select one or more .jar files.";
-    } else if (ignored > 0) {
-        status.textContent = `${patchable.length} ready, ${ignored} will be skipped.`;
-    } else {
-        status.textContent = `${patchable.length} file${patchable.length === 1 ? "" : "s"} ready to patch.`;
+        return "Select one or more .jar files.";
     }
+    if (ignored > 0) {
+        return `${patchable.length} ready, ${ignored} will be skipped.`;
+    }
+    return `${patchable.length} file${patchable.length === 1 ? "" : "s"} ready to patch.`;
+}
+
+function runtimeStatusSuffix() {
+    if (!selectedFileList.some(isPatchableJar)) return "";
+
+    if (runtimeState === "loading") {
+        return " Preparing Java runtime…";
+    }
+    if (runtimeState === "ready") {
+        const timing = runtimeInitMs === null ? "" : ` in ${formatDuration(runtimeInitMs)}`;
+        return ` Runtime ready${timing}.`;
+    }
+    if (runtimeState === "failed") {
+        return " Runtime preload failed; Patch will retry.";
+    }
+    return "";
+}
+
+function updateSelectionStatus() {
+    status.textContent = selectionStatusBase() + runtimeStatusSuffix();
 }
 
 function uniqueFiles(files) {
@@ -238,6 +308,10 @@ function setBusy(busy) {
 
 async function getPatcher() {
     if (!patcherPromise) {
+        runtimeState = "loading";
+        runtimeInitMs = null;
+        const startedAt = performance.now();
+
         patcherPromise = (async () => {
             await cheerpjInit({ version: 17, status: "none" });
 
@@ -246,10 +320,18 @@ async function getPatcher() {
             const library = await cheerpjRunLibrary(libraryPath);
             const WebPatcher = await library.com.patch.foliaphantom.web.WebPatcher;
             return await new WebPatcher();
-        })().catch(error => {
-            patcherPromise = undefined;
-            throw error;
-        });
+        })()
+            .then(patcher => {
+                runtimeInitMs = performance.now() - startedAt;
+                runtimeState = "ready";
+                return patcher;
+            })
+            .catch(error => {
+                patcherPromise = undefined;
+                runtimeInitMs = null;
+                runtimeState = "failed";
+                throw error;
+            });
     }
     return patcherPromise;
 }
@@ -274,9 +356,11 @@ function hasOutput(result) {
     return result.status === "success" || result.status === "partial";
 }
 
-function emptyResult(file, resultStatus, error) {
+function emptyResult(file, resultStatus, error, sizeBytes = 0, patchMs = 0) {
     return {
         file,
+        sizeBytes,
+        patchMs,
         status: resultStatus,
         patched: 0,
         skipped: 0,
@@ -304,6 +388,20 @@ function formatBytes(bytes) {
     }
 
     return `${value >= 10 ? value.toFixed(0) : value.toFixed(1)} ${unit}`;
+}
+
+function formatDuration(milliseconds) {
+    if (!Number.isFinite(milliseconds) || milliseconds <= 0) return "0 ms";
+    if (milliseconds < 1000) return `${Math.round(milliseconds)} ms`;
+
+    const seconds = milliseconds / 1000;
+    return `${seconds < 10 ? seconds.toFixed(2) : seconds.toFixed(1)} s`;
+}
+
+function metricMilliseconds(milliseconds) {
+    return Number.isFinite(milliseconds) && milliseconds > 0
+        ? Math.round(milliseconds)
+        : 0;
 }
 
 function parsePatchReport(text) {
@@ -352,7 +450,20 @@ function renderReport(results, total) {
     resultsContainer.replaceChildren(...results.map(createResultElement));
 
     const counts = resultCounts(results);
-    reportSummary.textContent = `${results.length}/${total} processed · ${counts.success} success · ${counts.partial} partial · ${counts.failed} failed · ${counts.skipped} skipped`;
+    const metrics = [];
+    if (runtimeInitMs !== null) {
+        metrics.push(`runtime ${formatDuration(runtimeInitMs)}`);
+    }
+
+    const totalPatchMs = results.reduce(
+            (sum, result) => sum + (result.patchMs || 0),
+            0);
+    if (totalPatchMs > 0) {
+        metrics.push(`patch ${formatDuration(totalPatchMs)}`);
+    }
+
+    const metricText = metrics.length > 0 ? ` · ${metrics.join(" · ")}` : "";
+    reportSummary.textContent = `${results.length}/${total} processed · ${counts.success} success · ${counts.partial} partial · ${counts.failed} failed · ${counts.skipped} skipped${metricText}`;
 }
 
 function createResultElement(result) {
@@ -368,9 +479,11 @@ function createResultElement(result) {
 
     const meta = document.createElement("span");
     meta.className = "result-meta";
+    const size = formatBytes(result.sizeBytes || 0);
+    const timing = result.patchMs > 0 ? ` · ${formatDuration(result.patchMs)}` : "";
     meta.textContent = hasOutput(result)
-        ? `${result.patched} patched / ${result.skipped} skipped / ${result.failed} unchanged`
-        : result.status;
+        ? `${result.patched} patched / ${result.skipped} skipped / ${result.failed} unchanged · ${size}${timing}`
+        : `${result.status} · ${size}${timing}`;
 
     head.append(name, meta);
     article.append(head);
@@ -426,7 +539,10 @@ function updateReportDownload(results) {
     const rows = [
         [
             "file",
+            "input_bytes",
             "status",
+            "runtime_init_ms",
+            "patch_ms",
             "patched_classes",
             "skipped_classes",
             "unchanged_classes",
@@ -436,7 +552,10 @@ function updateReportDownload(results) {
         ],
         ...results.map(result => [
             result.file,
+            result.sizeBytes,
             result.status,
+            metricMilliseconds(runtimeInitMs),
+            metricMilliseconds(result.patchMs),
             result.patched,
             result.skipped,
             result.failed,

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "pasta-web-e2e",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:e2e": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.62.1"
+  }
+}

--- a/web/playwright.config.mjs
+++ b/web/playwright.config.mjs
@@ -1,0 +1,25 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 120_000,
+  expect: {
+    timeout: 20_000
+  },
+  workers: 1,
+  reporter: process.env.CI
+    ? [["line"], ["html", { outputFolder: "playwright-report", open: "never" }]]
+    : "list",
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    headless: true,
+    trace: "retain-on-failure"
+  },
+  webServer: {
+    command: "python3 -m http.server 4173 --bind 127.0.0.1",
+    url: "http://127.0.0.1:4173/",
+    reuseExistingServer: !process.env.CI,
+    stdout: "pipe",
+    stderr: "pipe"
+  }
+});

--- a/web/tests/README.md
+++ b/web/tests/README.md
@@ -1,0 +1,3 @@
+# Browser E2E fixtures
+
+`web.spec.mjs` creates its JAR fixtures at runtime using the JDK `jar` tool. No plugin binaries are committed to the repository.

--- a/web/tests/web.spec.mjs
+++ b/web/tests/web.spec.mjs
@@ -1,0 +1,134 @@
+import { test, expect } from "@playwright/test";
+import { execFileSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+function createJar(name, entries) {
+  const root = mkdtempSync(join(tmpdir(), "pasta-web-e2e-"));
+  const jarPath = join(root, name);
+  const args = ["--create", "--file", jarPath];
+
+  for (const [entryName, content] of Object.entries(entries)) {
+    const path = join(root, entryName);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, content);
+    args.push("-C", root, entryName);
+  }
+
+  execFileSync("jar", args);
+  return { root, jarPath };
+}
+
+function readJarEntry(jarPath, entryName) {
+  return execFileSync("unzip", ["-p", jarPath, entryName], {
+    encoding: "utf8"
+  });
+}
+
+async function dropJar(page, jarPath, fileName) {
+  const base64 = readFileSync(jarPath).toString("base64");
+
+  await page.locator("#drop-zone").evaluate((zone, payload) => {
+    const binary = atob(payload.base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index++) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+
+    const transfer = new DataTransfer();
+    transfer.items.add(new File(
+      [bytes],
+      payload.fileName,
+      { type: "application/java-archive" }
+    ));
+
+    zone.dispatchEvent(new DragEvent("drop", {
+      bubbles: true,
+      cancelable: true,
+      dataTransfer: transfer
+    }));
+  }, { base64, fileName });
+}
+
+test("browser patching covers warmup, reset, success, partial output, and metrics", async ({ page }) => {
+  const success = createJar("paper-fixture.jar", {
+    "paper-plugin.yml": [
+      "name: PaperFixture",
+      "version: 1.0",
+      "main: example.Main",
+      "api-version: '1.21'",
+      ""
+    ].join("\n")
+  });
+  const partial = createJar("partial-fixture.jar", {
+    "plugin.yml": [
+      "name: PartialFixture",
+      "version: 1.0",
+      "main: example.Main",
+      ""
+    ].join("\n"),
+    "Broken.class": Buffer.from("not-a-class org/bukkit/ scheduler marker")
+  });
+
+  try {
+    await page.goto("/");
+
+    await dropJar(page, success.jarPath, "paper-fixture.jar");
+    await expect(page.locator("#selection-summary")).toContainText("1 selected");
+    await expect(page.locator("#status")).toContainText("ready");
+
+    await page.locator("#clear").click();
+    await expect(page.locator("#selection")).toBeHidden();
+    await expect(page.locator("#status")).toHaveText("Select one or more .jar files.");
+
+    await page.locator("#file").setInputFiles(success.jarPath);
+    const successDownloadPromise = page.waitForEvent("download");
+    await page.locator("#patch").click();
+    const successDownload = await successDownloadPromise;
+    const successPath = await successDownload.path();
+
+    expect(successPath).not.toBeNull();
+    expect(successDownload.suggestedFilename()).toBe("patched-paper-fixture.jar");
+    expect(readJarEntry(successPath, "paper-plugin.yml"))
+      .toContain("folia-supported: true");
+    await expect(page.locator("#status")).toContainText("1 succeeded");
+    await expect(page.locator(".result-meta")).toContainText(/(ms|s)$/);
+    await expect(page.locator("#report-summary")).toContainText("runtime");
+    await expect(page.locator("#report-summary")).toContainText("patch");
+
+    await page.locator("#file").setInputFiles(partial.jarPath);
+    const partialDownloadPromise = page.waitForEvent("download");
+    await page.locator("#patch").click();
+    const partialDownload = await partialDownloadPromise;
+    const partialPath = await partialDownload.path();
+
+    expect(partialPath).not.toBeNull();
+    expect(readJarEntry(partialPath, "plugin.yml"))
+      .toContain("folia-supported: true");
+    await expect(page.locator("#status")).toContainText("1 partial");
+    await expect(page.locator(".result-error"))
+      .toContainText("left unchanged after a transform error");
+    await expect(page.locator("summary"))
+      .toContainText("1 unchanged classes");
+
+    const reportPromise = page.waitForEvent("download");
+    await page.locator("#report-download").click();
+    const reportDownload = await reportPromise;
+    const reportPath = await reportDownload.path();
+    const report = readFileSync(reportPath, "utf8");
+
+    expect(report).toContain("\"runtime_init_ms\"");
+    expect(report).toContain("\"patch_ms\"");
+    expect(report).toContain("\"partial\"");
+  } finally {
+    rmSync(success.root, { recursive: true, force: true });
+    rmSync(partial.root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

The browser frontend works, but its cold-start latency, browser-specific memory behavior, Paper plugin metadata support, and real end-to-end verification were not yet strong enough to call the Web path fast and robust with evidence.

## Changes

- start CheerpJ warm-up as soon as a patchable JAR is selected, reusing the same initialization promise when Patch is clicked;
- record local runtime-init and per-JAR end-to-end timings with `performance.now()` and include them in the UI/CSV report;
- use a streaming sequential core path when `parallel=false` so the browser does not retain every expanded JAR entry in Java memory before writing output;
- keep the existing parallel preparation path for CLI/desktop/server usage;
- add `paper-plugin.yml` support for `folia-supported: true` alongside classic `plugin.yml`;
- add JUnit coverage for Paper plugin metadata in sequential and parallel modes;
- add Playwright/Chromium E2E coverage for drag-and-drop, reset, Paper descriptor transformation, downloaded JAR inspection, partial-class failure behavior, and timing CSV fields;
- run browser E2E on PRs targeting `develop` and gate GitHub Pages deployment on the same test;
- document Web runtime behavior and local verification.

## Safety

Browser JAR bytes remain local. No upload endpoint, analytics, filename telemetry, or remote conversion path is added. Existing archive size/entry limits still apply to every input entry.

A successful transformation or injected `folia-supported: true` field is still not a formal certification that arbitrary plugin state is thread-safe on Folia.

## Verification

All GitHub-hosted checks are green on the current head:

- ✅ Verify (Java 21): full Maven reactor `verify` completed successfully;
- ✅ Core tests: 13 total tests, including 10 `PluginPatcherResourceLimitTest` cases and 3 scheduler transformer tests, with 0 failures/errors;
- ✅ Pages browser test: real headless Chromium + CheerpJ E2E completed successfully;
- ✅ Browser E2E covers drag-and-drop/reset, `paper-plugin.yml` mutation, actual downloaded JAR inspection, partial transform failure recovery, and local timing CSV fields;
- ✅ CodeQL;
- ✅ dependency-review;
- ✅ Peperoncino Action Smoke Test.

The E2E fixtures are generated at test time and no plugin binary is committed.