### PR TITLE
docs: establish pasta community foundation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,83 @@
+name: Bug report
+description: Report a reproducible problem in pasta
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. Please provide enough detail to distinguish a pasta transformation defect from plugin-specific Folia concurrency behavior.
+
+  - type: input
+    id: version
+    attributes:
+      label: pasta version or commit
+      description: Release tag, commit SHA, or branch used.
+      placeholder: "v2.0.0 / abc1234 / develop"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: mode
+    attributes:
+      label: Execution mode
+      options:
+        - Browser
+        - GitHub Actions
+        - CLI
+        - GUI
+        - Server plugin
+        - Library / custom integration
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Java version, server implementation/version, operating system, and other relevant runtime details.
+      placeholder: "Java 21, Folia 1.21.x, Ubuntu 24.04"
+    validations:
+      required: true
+
+  - type: textarea
+    id: input
+    attributes:
+      label: Input and reproduction
+      description: Describe the plugin/JAR or minimal fixture and the exact steps needed to reproduce the issue. Do not upload proprietary or sensitive artifacts without permission.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, stack traces, or transformation output
+      description: Paste relevant output. Remove credentials, tokens, private server data, and unrelated personal information.
+      render: text
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing Issues and Discussions for the same problem.
+          required: true
+        - label: I tested with a current pasta release or recent commit when practical.
+          required: true
+        - label: I understand that successful bytecode transformation does not by itself guarantee arbitrary plugin thread safety under Folia.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions, ideas, and community discussion
+    url: https://github.com/MARVserver/pasta/discussions
+    about: Ask for help, explore ideas, and share pasta usage in GitHub Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,65 @@
+name: Feature request
+description: Propose a concrete, scoped improvement to pasta
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use Discussions first when the idea is still exploratory. Use this template when the problem and desired outcome are concrete enough to evaluate.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user or contributor problem should pasta solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior or workflow you want, not only an implementation detail.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Core transformer
+        - CLI
+        - GUI
+        - Browser
+        - Server plugin
+        - GitHub Actions
+        - Documentation
+        - Contributor experience
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Existing workarounds, rejected approaches, or related tools/issues.
+
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility and risk
+      description: Note any implications for Folia ownership/threading, bytecode compatibility, Java versions, plugin behavior, or deployment.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing Issues and Discussions for related requests.
+          required: true
+        - label: This request describes a concrete outcome rather than a general support question.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Problem
+
+<!-- What user or contributor problem does this PR solve? Link related Issues/Discussions when applicable. -->
+
+## Change
+
+<!-- Summarize the important behavioral or architectural changes. -->
+
+## Verification
+
+<!-- List automated tests, build commands, and manual checks you ran. -->
+
+- [ ] `cd folia-phantom && mvn clean verify` (when applicable)
+- [ ] Relevant manual workflow checked (CLI / GUI / browser / plugin / GitHub Action)
+- [ ] User-facing documentation updated when behavior or commands changed
+
+## Risk
+
+<!-- Describe compatibility, bytecode, scheduler/thread-ownership, Java-version, or deployment risks. Write "None identified" only after considering them. -->
+
+## Contributor checklist
+
+- [ ] I read `CONTRIBUTING.md` and applicable guidance in `AGENTS.md`.
+- [ ] This PR targets `develop` unless a maintainer requested another base branch.
+- [ ] The change is focused and avoids unrelated formatting or refactoring churn.
+- [ ] I have not included credentials, private server data, or artifacts I do not have permission to share.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Code of Conduct
+
+## Our standard
+
+The pasta community is for technical collaboration around Bukkit-to-Folia compatibility, bytecode transformation, tooling, and related integrations.
+
+Participants are expected to:
+
+- be respectful and specific when reviewing code or discussing technical disagreements;
+- assume good intent while still asking for evidence, reproduction steps, and verification;
+- keep discussions relevant to the project and its users;
+- welcome contributors with different levels of experience;
+- avoid harassment, discrimination, personal attacks, threats, doxxing, or sustained disruption;
+- respect privacy, licenses, and the security boundaries of other projects and servers.
+
+Technical criticism is encouraged when it is directed at code, behavior, architecture, or evidence rather than at people.
+
+## Scope
+
+This code applies to repository Issues, Pull Requests, Discussions, project-managed community spaces, and project-related interactions where someone is representing pasta or MARVserver.
+
+## Enforcement
+
+Maintainers may edit or remove content, close or lock conversations, reject contributions, or restrict participation when behavior conflicts with this code.
+
+If a conversation is becoming unproductive, move the discussion back to reproducible facts: the affected pasta version or commit, platform and Java version, input conditions, expected behavior, actual behavior, logs, and a minimal reproduction where possible.
+
+For conduct concerns that should not be handled publicly, contact a repository maintainer through an appropriate private GitHub channel available to you. Do not post private personal information in Issues or Discussions.
+
+## Attribution
+
+This is a project-specific code of conduct written for pasta. It is intentionally concise so expectations are easy to apply in day-to-day technical collaboration.

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -1,0 +1,42 @@
+# pasta community
+
+pasta is an open technical project for improving Bukkit-to-Folia compatibility through bytecode transformation and related tooling. The community is organized around reproducible engineering work: concrete examples, minimal test cases, clear compatibility constraints, and reviewable changes.
+
+## Where to participate
+
+- **GitHub Discussions** — questions, early-stage ideas, usage reports, experiments, and general project conversation: https://github.com/MARVserver/pasta/discussions
+- **GitHub Issues** — reproducible bugs and concrete feature requests: https://github.com/MARVserver/pasta/issues
+- **Pull Requests** — focused implementation and documentation changes. Read [CONTRIBUTING.md](CONTRIBUTING.md) and [AGENTS.md](AGENTS.md) first.
+
+## Good community reports
+
+Useful reports usually include:
+
+1. the pasta release, branch, or commit;
+2. execution mode: browser, GitHub Action, CLI, GUI, server plugin, or custom integration;
+3. Java version and server implementation/version when relevant;
+4. a minimal or clearly described input plugin/JAR;
+5. expected and actual behavior;
+6. logs, stack traces, transformed output, or a minimal reproduction;
+7. whether the problem also occurs with a current release or recent `develop` commit.
+
+Do not publish credentials, private server data, proprietary artifacts you cannot share, or unrelated personal information.
+
+## From idea to contribution
+
+A typical contribution path is:
+
+1. Start in Discussions if the problem or design is still unclear.
+2. Open an Issue once there is a concrete defect or outcome to track.
+3. Agree on scope and compatibility constraints for non-trivial changes.
+4. Branch from `develop` and implement a focused change.
+5. Run the relevant verification described in [CONTRIBUTING.md](CONTRIBUTING.md).
+6. Open a Pull Request against `develop` with problem, change, verification, and risk notes.
+
+Small documentation fixes can go directly to a Pull Request when the intended correction is unambiguous.
+
+## Technical discussion standard
+
+pasta changes can affect bytecode, scheduler behavior, Folia ownership rules, Java compatibility, and plugin runtime behavior. Strong technical disagreement is acceptable; unsupported personal criticism is not. Prefer evidence that can be reproduced and reviewed.
+
+See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for participation expectations and [SUPPORT.md](SUPPORT.md) for choosing the right support channel.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,32 @@
+# Support
+
+Use the channel that best matches what you need so maintainers and contributors can respond efficiently.
+
+## Questions and usage help
+
+Use [GitHub Discussions](https://github.com/MARVserver/pasta/discussions) for:
+
+- setup and usage questions;
+- compatibility questions that are not yet confirmed bugs;
+- ideas that need exploration before becoming a concrete feature request;
+- examples, experiments, and reports about plugins patched with pasta.
+
+When asking for help, include the pasta version or commit, Java version, server implementation/version, how you ran pasta (browser, CLI, GUI, server plugin, or GitHub Action), and relevant logs or error output.
+
+## Confirmed bugs
+
+Use [GitHub Issues](https://github.com/MARVserver/pasta/issues) when you can describe a reproducible defect in pasta. Use the bug report template and provide a minimal reproduction when practical.
+
+A transformed plugin failing under Folia does not automatically mean the transformer is defective: bytecode transformation cannot prove arbitrary plugin state is thread-safe. Please include enough evidence to distinguish a transformation problem from plugin-specific concurrency behavior.
+
+## Feature requests
+
+Use the feature request Issue template for concrete, scoped changes. Broader design ideas should usually start in Discussions so the problem and constraints can be refined first.
+
+## Pull requests
+
+Before opening a Pull Request, read [CONTRIBUTING.md](CONTRIBUTING.md) and [AGENTS.md](AGENTS.md). Pull Requests should normally target `develop`.
+
+## Security-sensitive reports
+
+Do not publish exploit details, credentials, private server data, or other sensitive information in a public Issue or Discussion. Use a private GitHub contact/reporting path available for this repository or contact a maintainer privately before disclosure.


### PR DESCRIPTION
## Problem

pasta already has GitHub Discussions enabled and a detailed contributor guide, but the repository does not yet provide a clear community entry point or structured Issue/PR intake.

## Change

This PR adds a lightweight community foundation:

- `CODE_OF_CONDUCT.md` with project-specific participation expectations;
- `SUPPORT.md` routing questions/ideas to Discussions and reproducible bugs to Issues;
- `COMMUNITY.md` describing where and how to participate;
- structured bug report and feature request Issue forms;
- Issue template configuration that directs general questions to Discussions;
- a Pull Request template aligned with the existing `CONTRIBUTING.md` workflow.

## Verification

- Confirmed the repository has GitHub Discussions enabled.
- Confirmed existing `.github` content did not already contain Issue or PR templates.
- Compared the branch against `develop`: 7 files added, no existing files modified.

## Risk

Low. These changes affect repository community workflows and documentation only; no runtime, bytecode, build, or deployment behavior changes.
