### PR TITLE
ci: publish Maven artifacts to GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 concurrency:
   group: release-${{ github.ref }}
@@ -60,6 +61,9 @@ jobs:
           java-version: '21'
           cache: maven
           cache-dependency-path: folia-phantom/**/pom.xml
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
 
       - name: Set Maven release version
         run: >-
@@ -70,6 +74,42 @@ jobs:
 
       - name: Verify and package
         run: mvn --batch-mode --no-transfer-progress --fail-at-end clean verify
+
+      - name: Check GitHub Packages version
+        id: package
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          PACKAGE_URL="https://maven.pkg.github.com/MARVserver/pasta/com/patch/folia-phantom/${VERSION}/folia-phantom-${VERSION}.pom"
+          STATUS="$(curl --location --silent --show-error --output /dev/null --write-out '%{http_code}' \
+            --user "${GITHUB_ACTOR}:${GITHUB_TOKEN}" \
+            "${PACKAGE_URL}")"
+
+          case "${STATUS}" in
+            200)
+              echo "GitHub Packages already contains com.patch:folia-phantom:${VERSION}; skipping deploy."
+              echo "publish=false" >> "$GITHUB_OUTPUT"
+              ;;
+            404)
+              echo "GitHub Packages does not contain version ${VERSION}; it will be published."
+              echo "publish=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unexpected GitHub Packages response: HTTP ${STATUS}" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Publish Maven packages
+        if: steps.package.outputs.publish == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          mvn --batch-mode --no-transfer-progress --fail-at-end
+          -DskipTests deploy
 
       - name: Stage release artifacts
         run: |

--- a/folia-phantom/.mvn/maven.config
+++ b/folia-phantom/.mvn/maven.config
@@ -1,0 +1,8 @@
+-Daether.connector.http.retryHandler.count=8
+-Daether.connector.http.retryHandler.interval=10000
+-Daether.connector.http.retryHandler.intervalMax=120000
+-Daether.connector.http.retryHandler.serviceUnavailable=429,503
+-Daether.transport.http.retryHandler.count=8
+-Daether.transport.http.retryHandler.interval=10000
+-Daether.transport.http.retryHandler.intervalMax=120000
+-Daether.transport.http.retryHandler.serviceUnavailable=429,503

--- a/folia-phantom/pom.xml
+++ b/folia-phantom/pom.xml
@@ -78,6 +78,14 @@
         </repository>
     </repositories>
 
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/MARVserver/pasta</url>
+        </repository>
+    </distributionManagement>
+
     <build>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
## Problem

Release builds currently publish JARs to GitHub Releases, but do not deploy Maven artifacts to GitHub Packages, so the repository's Packages page cannot expose the pasta Maven reactor artifacts. Maven Central can also transiently throttle GitHub Actions runners with HTTP 429, which can make an otherwise valid build fail during dependency/plugin resolution.

## Change

- Configure `folia-phantom/pom.xml` with GitHub Packages `distributionManagement` targeting `https://maven.pkg.github.com/MARVserver/pasta`.
- Grant the release workflow `packages: write` permission.
- Configure `actions/setup-java` with the `github` Maven server and `GITHUB_TOKEN` authentication.
- Publish the full Maven reactor with `mvn deploy` after verification.
- Check whether the parent package version already exists before deploying, so rerunning a release does not attempt to overwrite an immutable Maven version.
- Add `folia-phantom/.mvn/maven.config` with Maven Resolver retry settings for HTTP 429/503 responses (8 attempts, 10 second initial interval, 120 second maximum interval), covering Maven Resolver 1.x and newer transport property names.
- Preserve the existing GitHub Release artifact publishing flow.

## Verification

- Compared against `develop`: only Maven/package/release configuration is changed; runtime Java code is untouched.
- The GitHub Packages configuration follows GitHub's Maven registry model (`distributionManagement` + `GITHUB_TOKEN` + `packages: write`).
- The retry configuration uses Maven Resolver's native HTTP retry handling, including `Retry-After` support for HTTP 429/503, instead of retrying the entire deploy command.
- Existing `clean verify`, workflow artifact upload, checksums, and GitHub Release publication remain in place.

## Risk

Low to moderate. Runtime code is unchanged. The main operational changes are authenticated Maven deploys and longer retry behavior during repository throttling. GitHub Packages versions are immutable, so the workflow checks for an existing parent version and skips redeployment when found.
