### PR TITLE
Include Paper API for ASM frame resolution

### DIFF
--- a/folia-phantom/folia-phantom-core/pom.xml
+++ b/folia-phantom/folia-phantom-core/pom.xml
@@ -37,6 +37,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
+            <scope>compile</scope>
         </dependency>
         <!-- SLF4J API: ロギング抽象化層 -->
         <dependency>


### PR DESCRIPTION
## Summary

Follow-up to #111.

`SafeClassWriter` can now resolve classes from the input plugin JAR, but standalone patcher builds still inherit `paper-api` as `provided`. That means Bukkit/Paper types are absent from the runtime classpath while ASM recomputes frames.

This breaks multi-catch handlers such as Multiverse-Core's:

```java
catch (InvalidConfigurationException | IOException e)
```

ASM needs to merge those catch types to `java/lang/Exception`. If `InvalidConfigurationException` cannot be loaded, the existing fallback returns `java/lang/Object`, causing JVM verification to fail with:

```text
java.lang.VerifyError: Bad type on operand stack
Type 'java/lang/Object' is not assignable to 'java/lang/Exception'
```

## Change

Override the inherited dependency-management scope for `paper-api` in `folia-phantom-core` from `provided` to `compile` so shaded standalone consumers include Paper/Bukkit API type metadata needed by `ClassWriter.COMPUTE_FRAMES`.

Together with #111, this covers both plugin-local types and Bukkit/Paper API types during frame computation.