### PR TITLE
Fix World operation receiver stack balance

### DIFF
--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/transformer/WorldGenClassTransformer.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/transformer/WorldGenClassTransformer.java
@@ -4,94 +4,45 @@ import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.InsnNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
 import java.util.List;
 
 /**
- * ワールド生成関連 + ワールド操作の API 呼び出しを非同期化するトランスフォーマー。
- *
- * <p>Folia ではワールド操作は適切なリージョンスケジューラ上で行う必要がある。
- * 本トランスフォーマーは以下の呼び出しを変換する:
- * <ul>
- *   <li>{@code Bukkit.createWorld(WorldCreator)} → {@code FoliaPatcher.createWorld(WorldCreator)}</li>
- *   <li>{@code new WorldCreator(name).createWorld()} → {@code FoliaPatcher.createWorld(WorldCreator)}</li>
- *   <li>{@code plugin.getDefaultWorldGenerator(name, id)} → {@code FoliaPatcher.getDefaultWorldGenerator(plugin, name, id)}</li>
- *   <li>{@code World.spawn(Location, Class)} → {@code FoliaPatcher.safeSpawn(location, clazz)}</li>
- *   <li>{@code World.dropItem(Location, ItemStack)} → {@code FoliaPatcher.safeDropItem(location, item)}</li>
- *   <li>{@code World.dropItemNaturally(Location, ItemStack)} → {@code FoliaPatcher.safeDropItemNaturally(location, item)}</li>
- *   <li>{@code World.createExplosion(Location, float)} → {@code FoliaPatcher.safeCreateExplosion(location, power)}</li>
- *   <li>{@code World.strikeLightning(Location)} → {@code FoliaPatcher.safeStrikeLightning(location)}</li>
- * </ul>
- * </p>
+ * {@code Bukkit.createWorld} / {@code WorldCreator.createWorld} と
+ * {@code World} 操作呼び出しを Folia 互換ラッパーへ置き換える。
  */
 public final class WorldGenClassTransformer implements ClassTransformer, Opcodes {
 
-    /** Bukkit クラスの内部名 */
     private static final String BUKKIT_OWNER = "org/bukkit/Bukkit";
-
-    /** WorldCreator クラスの内部名 */
     private static final String WORLD_CREATOR_OWNER = "org/bukkit/WorldCreator";
-
-    /** Plugin クラスの内部名 */
     private static final String PLUGIN_OWNER = "org/bukkit/plugin/Plugin";
-
-    /** World クラスの内部名 */
     private static final String WORLD_OWNER = "org/bukkit/World";
-
-    /** FoliaPatcher の内部名 */
     private static final String PATCHER_OWNER = "com/patch/foliaphantom/patcher/FoliaPatcher";
 
-    /** Bukkit.createWorld メソッド名 */
     private static final String CREATE_WORLD = "createWorld";
-
-    /** WorldCreator.createWorld メソッド名 */
     private static final String WORLD_CREATOR_CREATE = "createWorld";
-
-    /** Plugin.getDefaultWorldGenerator メソッド名 */
     private static final String GET_DEFAULT_WORLD_GENERATOR = "getDefaultWorldGenerator";
 
-    /** FoliaPatcher.createWorld の記述子 */
     private static final String CREATE_WORLD_DESC =
             "(Lorg/bukkit/WorldCreator;)Lorg/bukkit/World;";
-
-    /** FoliaPatcher.getDefaultWorldGenerator の記述子 */
     private static final String GET_DEFAULT_WORLD_GENERATOR_DESC =
             "(Lorg/bukkit/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;)Lorg/bukkit/generator/ChunkGenerator;";
-
-    /** safeSpawn の記述子 */
     private static final String SPAWN_DESC =
             "(Lorg/bukkit/Location;Ljava/lang/Class;)Lorg/bukkit/entity/Entity;";
-
-    /** safeDropItem の記述子 */
     private static final String DROP_ITEM_DESC =
             "(Lorg/bukkit/Location;Lorg/bukkit/inventory/ItemStack;)Lorg/bukkit/entity/Item;";
-
-    /** safeDropItemNaturally の記述子 */
     private static final String DROP_ITEM_NATURALLY_DESC =
             "(Lorg/bukkit/Location;Lorg/bukkit/inventory/ItemStack;)Lorg/bukkit/entity/Item;";
-
-    /** safeCreateExplosion の記述子（float のみ） */
     private static final String EXPLOSION_1_DESC =
             "(Lorg/bukkit/Location;F)Z";
-
-    /** safeCreateExplosion の記述子（float + boolean） */
     private static final String EXPLOSION_2_DESC =
             "(Lorg/bukkit/Location;FZ)Z";
-
-    /** safeStrikeLightning の記述子 */
     private static final String STRIKE_LIGHTNING_DESC =
             "(Lorg/bukkit/Location;)Lorg/bukkit/entity/LightningStrike;";
 
-    /**
-     * クラスノード内の全メソッドを走査し、
-     * ワールド生成/操作関連の呼び出しを変換する。
-     *
-     * @param classNode  変換対象のクラスノード
-     * @param className  クラス内部名
-     * @param writer     出力先の ClassWriter
-     * @return 変換後のバイト配列
-     */
     @Override
     public byte[] transform(ClassNode classNode, String className, ClassWriter writer) {
         List<MethodNode> methods = classNode.methods;
@@ -106,28 +57,17 @@ public final class WorldGenClassTransformer implements ClassTransformer, Opcodes
         return writer.toByteArray();
     }
 
-    /**
-     * 単一メソッド内のワールド生成/操作関連呼び出しを置き換える。
-     *
-     * @param method 変換対象のメソッドノード
-     */
     private void transformMethod(MethodNode method) {
         AbstractInsnNode[] insns = method.instructions.toArray();
         for (AbstractInsnNode insn : insns) {
             if (insn instanceof MethodInsnNode methodInsn) {
                 replaceIfWorldGenCall(methodInsn);
-                replaceIfWorldOperation(methodInsn);
+                replaceIfWorldOperation(method, methodInsn);
             }
         }
     }
 
-    /**
-     * メソッド呼び出しノードがワールド生成関連であれば変換する。
-     *
-     * @param methodInsn 検査対象のメソッド呼び出しノード
-     */
     private void replaceIfWorldGenCall(MethodInsnNode methodInsn) {
-        // Bukkit.createWorld の変換
         if (BUKKIT_OWNER.equals(methodInsn.owner)
                 && CREATE_WORLD.equals(methodInsn.name)) {
             methodInsn.owner = PATCHER_OWNER;
@@ -137,7 +77,6 @@ public final class WorldGenClassTransformer implements ClassTransformer, Opcodes
             methodInsn.itf = false;
             return;
         }
-        // WorldCreator.createWorld の変換
         if (WORLD_CREATOR_OWNER.equals(methodInsn.owner)
                 && WORLD_CREATOR_CREATE.equals(methodInsn.name)) {
             methodInsn.owner = PATCHER_OWNER;
@@ -147,7 +86,6 @@ public final class WorldGenClassTransformer implements ClassTransformer, Opcodes
             methodInsn.itf = false;
             return;
         }
-        // Plugin.getDefaultWorldGenerator の変換
         if (PLUGIN_OWNER.equals(methodInsn.owner)
                 && GET_DEFAULT_WORLD_GENERATOR.equals(methodInsn.name)) {
             methodInsn.owner = PATCHER_OWNER;
@@ -158,76 +96,89 @@ public final class WorldGenClassTransformer implements ClassTransformer, Opcodes
         }
     }
 
-    /**
-     * World インスタンスメソッドの呼び出しを変換する。
-     */
-    private void replaceIfWorldOperation(MethodInsnNode methodInsn) {
+    private void replaceIfWorldOperation(MethodNode method, MethodInsnNode methodInsn) {
         if (!WORLD_OWNER.equals(methodInsn.owner)) {
             return;
         }
         String name = methodInsn.name;
         int argCount = getArgumentCount(methodInsn.desc);
 
-        // World.spawn(Location, Class) → safeSpawn(Location, Class)
-        // 引数3以上のオーバーロード（Consumer付きなど）はスタック不整合を避けるため対象外
         if ("spawn".equals(name) && argCount == 2) {
-            methodInsn.owner = PATCHER_OWNER;
-            methodInsn.name = "safeSpawn";
-            methodInsn.desc = SPAWN_DESC;
-            methodInsn.setOpcode(INVOKESTATIC);
-            methodInsn.itf = false;
+            discardWorldReceiver(method, methodInsn, 2);
+            rewriteWorldCall(methodInsn, "safeSpawn", SPAWN_DESC);
             return;
         }
-        // World.dropItem(Location, ItemStack) → safeDropItem(Location, ItemStack)
-        if ("dropItem".equals(name)) {
-            methodInsn.owner = PATCHER_OWNER;
-            methodInsn.name = "safeDropItem";
-            methodInsn.desc = DROP_ITEM_DESC;
-            methodInsn.setOpcode(INVOKESTATIC);
-            methodInsn.itf = false;
+        if ("dropItem".equals(name) && argCount == 2) {
+            discardWorldReceiver(method, methodInsn, 2);
+            rewriteWorldCall(methodInsn, "safeDropItem", DROP_ITEM_DESC);
             return;
         }
-        // World.dropItemNaturally(Location, ItemStack) → safeDropItemNaturally(Location, ItemStack)
-        if ("dropItemNaturally".equals(name)) {
-            methodInsn.owner = PATCHER_OWNER;
-            methodInsn.name = "safeDropItemNaturally";
-            methodInsn.desc = DROP_ITEM_NATURALLY_DESC;
-            methodInsn.setOpcode(INVOKESTATIC);
-            methodInsn.itf = false;
+        if ("dropItemNaturally".equals(name) && argCount == 2) {
+            discardWorldReceiver(method, methodInsn, 2);
+            rewriteWorldCall(methodInsn, "safeDropItemNaturally", DROP_ITEM_NATURALLY_DESC);
             return;
         }
-        // World.createExplosion(Location, float) → safeCreateExplosion(Location, float)
         if ("createExplosion".equals(name) && argCount == 2) {
-            methodInsn.owner = PATCHER_OWNER;
-            methodInsn.name = "safeCreateExplosion";
-            methodInsn.desc = EXPLOSION_1_DESC;
-            methodInsn.setOpcode(INVOKESTATIC);
-            methodInsn.itf = false;
+            discardWorldReceiver(method, methodInsn, 2);
+            rewriteWorldCall(methodInsn, "safeCreateExplosion", EXPLOSION_1_DESC);
             return;
         }
-        // World.createExplosion(Location, float, boolean) → safeCreateExplosion(Location, float, boolean)
-        // 引数4以上のオーバーロードはスタック不整合を避けるため対象外
         if ("createExplosion".equals(name) && argCount == 3) {
-            methodInsn.owner = PATCHER_OWNER;
-            methodInsn.name = "safeCreateExplosion";
-            methodInsn.desc = EXPLOSION_2_DESC;
-            methodInsn.setOpcode(INVOKESTATIC);
-            methodInsn.itf = false;
+            discardWorldReceiver(method, methodInsn, 3);
+            rewriteWorldCall(methodInsn, "safeCreateExplosion", EXPLOSION_2_DESC);
             return;
         }
-        // World.strikeLightning(Location) → safeStrikeLightning(Location)
-        if ("strikeLightning".equals(name)) {
-            methodInsn.owner = PATCHER_OWNER;
-            methodInsn.name = "safeStrikeLightning";
-            methodInsn.desc = STRIKE_LIGHTNING_DESC;
-            methodInsn.setOpcode(INVOKESTATIC);
-            methodInsn.itf = false;
+        if ("strikeLightning".equals(name) && argCount == 1) {
+            discardWorldReceiver(method, methodInsn, 1);
+            rewriteWorldCall(methodInsn, "safeStrikeLightning", STRIKE_LIGHTNING_DESC);
         }
     }
 
+    private static void rewriteWorldCall(
+            MethodInsnNode methodInsn, String name, String descriptor) {
+        methodInsn.owner = PATCHER_OWNER;
+        methodInsn.name = name;
+        methodInsn.desc = descriptor;
+        methodInsn.setOpcode(INVOKESTATIC);
+        methodInsn.itf = false;
+    }
+
     /**
-     * メソッド記述子から引数の数を取得する。
+     * Remove the original {@code World} invokevirtual receiver while leaving all
+     * category-1 arguments in their original order for the replacement static call.
+     * No locals or control-flow edges are introduced, so existing StackMapFrames
+     * remain valid under COMPUTE_MAXS.
      */
+    private static void discardWorldReceiver(
+            MethodNode method, MethodInsnNode call, int argumentCount) {
+        InsnList cleanup = new InsnList();
+        switch (argumentCount) {
+            case 1 -> {
+                // world, a -> a
+                cleanup.add(new InsnNode(SWAP));
+                cleanup.add(new InsnNode(POP));
+            }
+            case 2 -> {
+                // world, a, b -> a, b
+                cleanup.add(new InsnNode(DUP2_X1));
+                cleanup.add(new InsnNode(POP2));
+                cleanup.add(new InsnNode(POP));
+            }
+            case 3 -> {
+                // world, a, b, c -> a, b, c
+                cleanup.add(new InsnNode(DUP_X2));
+                cleanup.add(new InsnNode(POP));
+                cleanup.add(new InsnNode(DUP2_X2));
+                cleanup.add(new InsnNode(POP2));
+                cleanup.add(new InsnNode(SWAP));
+                cleanup.add(new InsnNode(POP));
+            }
+            default -> throw new IllegalArgumentException(
+                    "Unsupported World operation argument count: " + argumentCount);
+        }
+        method.instructions.insertBefore(call, cleanup);
+    }
+
     private static int getArgumentCount(String desc) {
         int count = 0;
         int i = 1;


### PR DESCRIPTION
## Summary

Fixes a verifier failure exposed after #113 began preserving existing StackMapFrames.

`WorldGenClassTransformer` rewrote instance calls such as:

```text
World.dropItem(Location, ItemStack)
```

to static `FoliaPatcher.safeDropItem(Location, ItemStack)` calls without consuming the original `World` receiver. That leaves one `org/bukkit/World` value on the operand stack. AuraSkills 2.3.12 reproduced this as:

```text
java.lang.VerifyError: Instruction type does not match stack map
Current frame stack: { org/bukkit/World }
Stackmap frame stack: { }
```

## Change

Before rewriting World instance calls, remove the receiver using stack-only permutations while preserving all original arguments in order. No temporary locals or new control-flow edges are introduced, so existing StackMapFrames remain valid with `COMPUTE_MAXS`.

Covered transformed operations:

- `World.spawn(Location, Class)`
- `World.dropItem(Location, ItemStack)`
- `World.dropItemNaturally(Location, ItemStack)`
- `World.createExplosion(Location, float)`
- `World.createExplosion(Location, float, boolean)`
- `World.strikeLightning(Location)`

This keeps the existing `FoliaPatcher.safe*` runtime signatures unchanged while restoring the same net operand-stack effect as the original invokevirtual calls.