### PR TITLE
Dispatch block reads to owning Folia region

### DIFF
--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/BlockReadBridge.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/BlockReadBridge.java
@@ -8,6 +8,7 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -58,12 +59,7 @@ public final class BlockReadBridge {
             return operation.get();
         }
 
-        Plugin targetPlugin = FoliaPatcher.plugin;
-        if (targetPlugin == null) {
-            throw new IllegalStateException(
-                    "FoliaPatcher plugin is not initialized for region-owned block read");
-        }
-
+        Plugin targetPlugin = JavaPlugin.getProvidingPlugin(BlockReadBridge.class);
         CompletableFuture<T> future = new CompletableFuture<>();
         Bukkit.getRegionScheduler().run(targetPlugin, location, task -> {
             try {

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/BlockReadBridge.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/BlockReadBridge.java
@@ -1,0 +1,107 @@
+package com.patch.foliaphantom.patcher;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+/**
+ * Region-owned synchronous Block reads used by patched plugins.
+ *
+ * <p>Legacy plugins frequently read block state during lifecycle callbacks that run on Folia's
+ * global thread. CraftBlock ultimately touches region-owned Level state, so these reads must be
+ * executed by the owning region. The bridge preserves the original synchronous Bukkit API contract
+ * by dispatching the read and waiting for the result.</p>
+ */
+public final class BlockReadBridge {
+
+    private static final long READ_TIMEOUT_SECONDS = 5L;
+
+    private BlockReadBridge() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static Material getType(Block block) {
+        return read(block, block::getType);
+    }
+
+    public static BlockData getBlockData(Block block) {
+        return read(block, block::getBlockData);
+    }
+
+    public static BlockState getState(Block block) {
+        return read(block, block::getState);
+    }
+
+    public static Collection<ItemStack> getDrops(Block block) {
+        return read(block, block::getDrops);
+    }
+
+    public static Collection<ItemStack> getDrops(Block block, ItemStack tool) {
+        return read(block, () -> block.getDrops(tool));
+    }
+
+    private static <T> T read(Block block, Supplier<T> operation) {
+        Location location = block.getLocation();
+        if (isOwningRegion(location)) {
+            return operation.get();
+        }
+
+        Plugin targetPlugin = FoliaPatcher.plugin;
+        if (targetPlugin == null) {
+            throw new IllegalStateException(
+                    "FoliaPatcher plugin is not initialized for region-owned block read");
+        }
+
+        CompletableFuture<T> future = new CompletableFuture<>();
+        Bukkit.getRegionScheduler().run(targetPlugin, location, task -> {
+            try {
+                future.complete(operation.get());
+            } catch (Throwable throwable) {
+                future.completeExceptionally(throwable);
+            }
+        });
+
+        try {
+            return future.get(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting for region-owned block read", exception);
+        } catch (ExecutionException exception) {
+            Throwable cause = exception.getCause();
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            if (cause instanceof Error error) {
+                throw error;
+            }
+            throw new IllegalStateException("Region-owned block read failed", cause);
+        } catch (TimeoutException exception) {
+            throw new IllegalStateException(
+                    "Timed out waiting for region-owned block read at " + location,
+                    exception);
+        }
+    }
+
+    private static boolean isOwningRegion(Location location) {
+        if (location == null || location.getWorld() == null) {
+            return false;
+        }
+        try {
+            return Bukkit.getServer().isOwnedByCurrentRegion(location);
+        } catch (NoSuchMethodError | Exception exception) {
+            return Bukkit.isPrimaryThread();
+        }
+    }
+}

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/PluginPatcher.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/PluginPatcher.java
@@ -58,7 +58,8 @@ public final class PluginPatcher {
         "com/patch/foliaphantom/patcher/FoliaPatcher$FoliaBukkitTask.class",
         "com/patch/foliaphantom/patcher/FoliaPatcher$FoliaChunkGenerator.class",
         "com/patch/foliaphantom/patcher/FoliaPatcher$ScheduledTaskStub.class",
-        "com/patch/foliaphantom/patcher/FoliaPatcher$TaskSchedulerFactory.class"
+        "com/patch/foliaphantom/patcher/FoliaPatcher$TaskSchedulerFactory.class",
+        "com/patch/foliaphantom/patcher/BlockReadBridge.class"
     };
 
     private final List<ClassTransformer> transformers;

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/transformer/ThreadSafetyTransformer.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/transformer/ThreadSafetyTransformer.java
@@ -6,81 +6,44 @@ import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
+
 import java.util.List;
-import java.util.Set;
 
 /**
- * {@code Block} の書き込み操作呼び出しをスレッドセーフなラッパーに置き換えるトランスフォーマー。
- *
- * <p>Folia はリージョン単位のマルチスレッドモデルを採用しており、
- * ワールドスレッド以外からのブロック操作呼び出しは
- * スレッドセーフではない。本トランスフォーマーはこれらの呼び出しを
- * {@code FoliaPatcher} のラッパーに置き換える。</p>
- *
- * <p>変換対象:
- * <ul>
- *   <li>{@code Block.setType(Material)} → {@code FoliaPatcher.safeSetType(block, material)}</li>
- *   <li>{@code Block.setType(Material, boolean)} → {@code FoliaPatcher.safeSetTypeWithPhysics(block, material, applyPhysics)}</li>
- *   <li>{@code Block.setBlockData(BlockData)} → {@code FoliaPatcher.safeSetBlockData(block, data)}</li>
- *   <li>{@code Block.setBlockData(BlockData, boolean)} → {@code FoliaPatcher.safeSetBlockData(block, data, applyPhysics)}</li>
- *   <li>{@code Block.breakNaturally()} → {@code FoliaPatcher.safeBreakNaturally(block)}</li>
- *   <li>{@code Block.breakNaturally(ItemStack)} → {@code FoliaPatcher.safeBreakNaturally(block, tool)}</li>
- *   <li>{@code Block.applyBoneMeal(BlockFace)} → {@code FoliaPatcher.safeApplyBoneMeal(block, face)}</li>
- * </ul>
- * </p>
+ * {@code Block} API calls that require region ownership are rewritten to Folia-safe bridges.
  */
 public final class ThreadSafetyTransformer implements ClassTransformer, Opcodes {
 
-    /** 変換対象の Block クラス内部名 */
     private static final String BLOCK_OWNER = "org/bukkit/block/Block";
-
-    /** FoliaPatcher の内部名 */
     private static final String PATCHER_OWNER = "com/patch/foliaphantom/patcher/FoliaPatcher";
+    private static final String BLOCK_READ_OWNER = "com/patch/foliaphantom/patcher/BlockReadBridge";
 
-    /** 変換対象メソッド名と対応する FoliaPatcher メソッドのマッピング */
-    private static final MethodMapping[] METHOD_MAPPINGS = {
-        // setType は引数数で分岐するため特別処理
-        new MethodMapping("setType", null, false),
-        // setBlockData も引数数で分岐
-        new MethodMapping("setBlockData", null, false),
-        // breakNaturally: 引数なし版と ItemStack版
-        new MethodMapping("breakNaturally", "safeBreakNaturally", false),
-        // applyBoneMeal: BlockFace 引数
-        new MethodMapping("applyBoneMeal", "safeApplyBoneMeal", false),
-    };
-
-    /** setType の記述子 */
     private static final String SET_TYPE_1_DESC =
             "(Lorg/bukkit/block/Block;Lorg/bukkit/Material;)V";
     private static final String SET_TYPE_2_DESC =
             "(Lorg/bukkit/block/Block;Lorg/bukkit/Material;Z)V";
-
-    /** setBlockData の記述子 */
     private static final String SET_BLOCK_DATA_1_DESC =
             "(Lorg/bukkit/block/Block;Lorg/bukkit/block/data/BlockData;)V";
     private static final String SET_BLOCK_DATA_2_DESC =
             "(Lorg/bukkit/block/Block;Lorg/bukkit/block/data/BlockData;Z)V";
-
-    /** breakNaturally の記述子（引数なし） */
     private static final String BREAK_NATURALLY_0_DESC =
             "(Lorg/bukkit/block/Block;)Z";
-    /** breakNaturally の記述子（ItemStack版） */
     private static final String BREAK_NATURALLY_1_DESC =
             "(Lorg/bukkit/block/Block;Lorg/bukkit/inventory/ItemStack;)Z";
-
-    /** applyBoneMeal の記述子 */
     private static final String APPLY_BONE_MEAL_DESC =
             "(Lorg/bukkit/block/Block;Lorg/bukkit/block/BlockFace;)Z";
 
-    /**
-     * クラスノード内の全メソッドを走査し、
-     * Block の書き込み操作呼び出しを FoliaPatcher のラッパーに置き換える。
-     *
-     * @param classNode  変換対象のクラスノード
-     * @param className  クラス内部名（未使用だがインターフェース規定で保持）
-     * @param writer     出力先の ClassWriter
-     * @return 変換後のバイト配列
-     */
+    private static final String GET_TYPE_DESC =
+            "(Lorg/bukkit/block/Block;)Lorg/bukkit/Material;";
+    private static final String GET_BLOCK_DATA_DESC =
+            "(Lorg/bukkit/block/Block;)Lorg/bukkit/block/data/BlockData;";
+    private static final String GET_STATE_DESC =
+            "(Lorg/bukkit/block/Block;)Lorg/bukkit/block/BlockState;";
+    private static final String GET_DROPS_0_DESC =
+            "(Lorg/bukkit/block/Block;)Ljava/util/Collection;";
+    private static final String GET_DROPS_1_DESC =
+            "(Lorg/bukkit/block/Block;Lorg/bukkit/inventory/ItemStack;)Ljava/util/Collection;";
+
     @Override
     public byte[] transform(ClassNode classNode, String className, ClassWriter writer) {
         List<MethodNode> methods = classNode.methods;
@@ -95,97 +58,82 @@ public final class ThreadSafetyTransformer implements ClassTransformer, Opcodes 
         return writer.toByteArray();
     }
 
-    /**
-     * 単一メソッド内の Block 呼び出しを置き換える。
-     *
-     * @param method 変換対象のメソッドノード
-     */
     private void transformMethod(MethodNode method) {
-        AbstractInsnNode[] insns = method.instructions.toArray();
-        for (int i = 0; i < insns.length; i++) {
-            if (insns[i] instanceof MethodInsnNode methodInsn) {
+        for (AbstractInsnNode insn : method.instructions.toArray()) {
+            if (insn instanceof MethodInsnNode methodInsn) {
                 replaceIfBlockCall(methodInsn);
             }
         }
     }
 
-    /**
-     * Block の呼び出しであれば適切なラッパーに置き換える。
-     */
     private void replaceIfBlockCall(MethodInsnNode methodInsn) {
         if (!BLOCK_OWNER.equals(methodInsn.owner)) {
             return;
         }
+
         String name = methodInsn.name;
         int argCount = getArgumentCount(methodInsn.desc);
 
-        // setType(Material)
+        if ("getType".equals(name) && argCount == 0) {
+            replaceStatic(methodInsn, BLOCK_READ_OWNER, "getType", GET_TYPE_DESC);
+            return;
+        }
+        if ("getBlockData".equals(name) && argCount == 0) {
+            replaceStatic(methodInsn, BLOCK_READ_OWNER, "getBlockData", GET_BLOCK_DATA_DESC);
+            return;
+        }
+        if ("getState".equals(name) && argCount == 0) {
+            replaceStatic(methodInsn, BLOCK_READ_OWNER, "getState", GET_STATE_DESC);
+            return;
+        }
+        if ("getDrops".equals(name) && argCount == 0) {
+            replaceStatic(methodInsn, BLOCK_READ_OWNER, "getDrops", GET_DROPS_0_DESC);
+            return;
+        }
+        if ("getDrops".equals(name) && argCount == 1
+                && methodInsn.desc.startsWith("(Lorg/bukkit/inventory/ItemStack;")) {
+            replaceStatic(methodInsn, BLOCK_READ_OWNER, "getDrops", GET_DROPS_1_DESC);
+            return;
+        }
+
         if ("setType".equals(name) && argCount == 1) {
-            methodInsn.owner = PATCHER_OWNER;
-            methodInsn.name = "safeSetType";
-            methodInsn.desc = SET_TYPE_1_DESC;
-            methodInsn.setOpcode(INVOKESTATIC);
-            methodInsn.itf = false;
+            replaceStatic(methodInsn, PATCHER_OWNER, "safeSetType", SET_TYPE_1_DESC);
             return;
         }
-        // setType(Material, boolean)
         if ("setType".equals(name) && argCount == 2) {
-            methodInsn.owner = PATCHER_OWNER;
-            methodInsn.name = "safeSetTypeWithPhysics";
-            methodInsn.desc = SET_TYPE_2_DESC;
-            methodInsn.setOpcode(INVOKESTATIC);
-            methodInsn.itf = false;
+            replaceStatic(methodInsn, PATCHER_OWNER, "safeSetTypeWithPhysics", SET_TYPE_2_DESC);
             return;
         }
-        // setBlockData(BlockData)
         if ("setBlockData".equals(name) && argCount == 1) {
-            methodInsn.owner = PATCHER_OWNER;
-            methodInsn.name = "safeSetBlockData";
-            methodInsn.desc = SET_BLOCK_DATA_1_DESC;
-            methodInsn.setOpcode(INVOKESTATIC);
-            methodInsn.itf = false;
+            replaceStatic(methodInsn, PATCHER_OWNER, "safeSetBlockData", SET_BLOCK_DATA_1_DESC);
             return;
         }
-        // setBlockData(BlockData, boolean)
         if ("setBlockData".equals(name) && argCount == 2) {
-            methodInsn.owner = PATCHER_OWNER;
-            methodInsn.name = "safeSetBlockData";
-            methodInsn.desc = SET_BLOCK_DATA_2_DESC;
-            methodInsn.setOpcode(INVOKESTATIC);
-            methodInsn.itf = false;
+            replaceStatic(methodInsn, PATCHER_OWNER, "safeSetBlockData", SET_BLOCK_DATA_2_DESC);
             return;
         }
-        // breakNaturally()
         if ("breakNaturally".equals(name) && argCount == 0) {
-            methodInsn.owner = PATCHER_OWNER;
-            methodInsn.name = "safeBreakNaturally";
-            methodInsn.desc = BREAK_NATURALLY_0_DESC;
-            methodInsn.setOpcode(INVOKESTATIC);
-            methodInsn.itf = false;
+            replaceStatic(methodInsn, PATCHER_OWNER, "safeBreakNaturally", BREAK_NATURALLY_0_DESC);
             return;
         }
-        // breakNaturally(ItemStack)
         if ("breakNaturally".equals(name) && argCount == 1) {
-            methodInsn.owner = PATCHER_OWNER;
-            methodInsn.name = "safeBreakNaturally";
-            methodInsn.desc = BREAK_NATURALLY_1_DESC;
-            methodInsn.setOpcode(INVOKESTATIC);
-            methodInsn.itf = false;
+            replaceStatic(methodInsn, PATCHER_OWNER, "safeBreakNaturally", BREAK_NATURALLY_1_DESC);
             return;
         }
-        // applyBoneMeal(BlockFace)
         if ("applyBoneMeal".equals(name)) {
-            methodInsn.owner = PATCHER_OWNER;
-            methodInsn.name = "safeApplyBoneMeal";
-            methodInsn.desc = APPLY_BONE_MEAL_DESC;
-            methodInsn.setOpcode(INVOKESTATIC);
-            methodInsn.itf = false;
+            replaceStatic(methodInsn, PATCHER_OWNER, "safeApplyBoneMeal", APPLY_BONE_MEAL_DESC);
         }
     }
 
-    /**
-     * メソッド記述子から引数の数を取得する。
-     */
+    private static void replaceStatic(
+            MethodInsnNode methodInsn, String owner, String name, String descriptor) {
+        methodInsn.owner = owner;
+        methodInsn.name = name;
+        methodInsn.desc = descriptor;
+        methodInsn.setOpcode(INVOKESTATIC);
+        methodInsn.itf = false;
+    }
+
     private static int getArgumentCount(String desc) {
         int count = 0;
         int i = 1;
@@ -210,8 +158,4 @@ public final class ThreadSafetyTransformer implements ClassTransformer, Opcodes 
         }
         return count;
     }
-
-    /** メソッドマッピングを保持する内部レコード */
-    private record MethodMapping(String originalName, String patcherName,
-                                 boolean isOverloaded) {}
 }

--- a/folia-phantom/folia-phantom-core/src/test/java/com/patch/foliaphantom/patcher/BlockReadBridgeTest.java
+++ b/folia-phantom/folia-phantom-core/src/test/java/com/patch/foliaphantom/patcher/BlockReadBridgeTest.java
@@ -1,0 +1,21 @@
+package com.patch.foliaphantom.patcher;
+
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertEquals;
+
+public class BlockReadBridgeTest {
+
+    @Test
+    public void exposesStackNeutralBlockReadSignatures() throws Exception {
+        Method getType = BlockReadBridge.class.getMethod("getType", org.bukkit.block.Block.class);
+        Method getBlockData = BlockReadBridge.class.getMethod("getBlockData", org.bukkit.block.Block.class);
+        Method getState = BlockReadBridge.class.getMethod("getState", org.bukkit.block.Block.class);
+
+        assertEquals(org.bukkit.Material.class, getType.getReturnType());
+        assertEquals(org.bukkit.block.data.BlockData.class, getBlockData.getReturnType());
+        assertEquals(org.bukkit.block.BlockState.class, getState.getReturnType());
+    }
+}

--- a/folia-phantom/folia-phantom-core/src/test/java/com/patch/foliaphantom/transformer/ThreadSafetyTransformerTest.java
+++ b/folia-phantom/folia-phantom-core/src/test/java/com/patch/foliaphantom/transformer/ThreadSafetyTransformerTest.java
@@ -1,0 +1,103 @@
+package com.patch.foliaphantom.transformer;
+
+import org.junit.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.VarInsnNode;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+public class ThreadSafetyTransformerTest implements Opcodes {
+
+    private static final String BLOCK = "org/bukkit/block/Block";
+    private static final String BRIDGE = "com/patch/foliaphantom/patcher/BlockReadBridge";
+
+    @Test
+    public void rewritesGetTypeToRegionOwnedBridgeWithoutChangingStackShape() {
+        ClassNode transformed = transform(classWithBlockRead(
+                "getType", "()Lorg/bukkit/Material;", "()Lorg/bukkit/Material;"));
+        MethodInsnNode call = findOnlyCall(transformed.methods.get(0));
+
+        assertNotNull(call);
+        assertEquals(INVOKESTATIC, call.getOpcode());
+        assertEquals(BRIDGE, call.owner);
+        assertEquals("getType", call.name);
+        assertEquals("(Lorg/bukkit/block/Block;)Lorg/bukkit/Material;", call.desc);
+        assertFalse(call.itf);
+    }
+
+    @Test
+    public void rewritesCommonBlockStateReads() {
+        assertReadRewrite(
+                "getBlockData",
+                "()Lorg/bukkit/block/data/BlockData;",
+                "(Lorg/bukkit/block/Block;)Lorg/bukkit/block/data/BlockData;");
+        assertReadRewrite(
+                "getState",
+                "()Lorg/bukkit/block/BlockState;",
+                "(Lorg/bukkit/block/Block;)Lorg/bukkit/block/BlockState;");
+        assertReadRewrite(
+                "getDrops",
+                "()Ljava/util/Collection;",
+                "(Lorg/bukkit/block/Block;)Ljava/util/Collection;");
+    }
+
+    private static void assertReadRewrite(String name, String originalDesc, String expectedDesc) {
+        ClassNode transformed = transform(classWithBlockRead(name, originalDesc, originalDesc));
+        MethodInsnNode call = findOnlyCall(transformed.methods.get(0));
+        assertNotNull(call);
+        assertEquals(INVOKESTATIC, call.getOpcode());
+        assertEquals(BRIDGE, call.owner);
+        assertEquals(name, call.name);
+        assertEquals(expectedDesc, call.desc);
+    }
+
+    private static ClassNode transform(ClassNode input) {
+        ThreadSafetyTransformer transformer = new ThreadSafetyTransformer();
+        ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+        byte[] bytes = transformer.transform(input, input.name, writer);
+        ClassNode output = new ClassNode(ASM9);
+        new ClassReader(bytes).accept(output, 0);
+        return output;
+    }
+
+    private static ClassNode classWithBlockRead(
+            String methodName, String invocationDesc, String returnDesc) {
+        ClassNode classNode = new ClassNode(ASM9);
+        classNode.version = V17;
+        classNode.access = ACC_PUBLIC;
+        classNode.name = "example/BlockReadFixture";
+        classNode.superName = "java/lang/Object";
+
+        MethodNode method = new MethodNode(
+                ASM9,
+                ACC_PUBLIC | ACC_STATIC,
+                "read",
+                "(Lorg/bukkit/block/Block;)" + returnDesc.substring(2),
+                null,
+                null);
+        method.instructions.add(new VarInsnNode(ALOAD, 0));
+        method.instructions.add(new MethodInsnNode(
+                INVOKEINTERFACE, BLOCK, methodName, invocationDesc, true));
+        method.instructions.add(new InsnNode(ARETURN));
+        classNode.methods.add(method);
+        return classNode;
+    }
+
+    private static MethodInsnNode findOnlyCall(MethodNode method) {
+        for (AbstractInsnNode instruction : method.instructions) {
+            if (instruction instanceof MethodInsnNode methodInsn) {
+                return methodInsn;
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes Multiverse-Core startup failures caused by direct block-state reads from Folia's global/plugin lifecycle thread.

Observed failure:

```text
Cannot read field "captureTreeGeneration" because Level.getCurrentWorldData() is null
at CraftBlock.getType(...)
at Multiverse BlockSafety.isUnsafeSpawnBody(...)
```

The existing transformer only wrapped Block writes. Reads such as `Block.getType()` remained direct and could touch region-owned world state from the wrong thread.

## Changes

- Add `BlockReadBridge`, a runtime helper bundled into every patched plugin.
- Dispatch synchronous block reads to the owning region with `RegionScheduler` and wait for the result with a bounded timeout.
- Resolve the actual patched plugin using `JavaPlugin.getProvidingPlugin(BlockReadBridge.class)` instead of relying on shared static state across plugin class loaders.
- Rewrite these calls to stack-neutral static bridge methods:
  - `Block.getType()`
  - `Block.getBlockData()`
  - `Block.getState()`
  - `Block.getDrops()`
  - `Block.getDrops(ItemStack)`
- Keep existing write-operation rewrites unchanged.
- Add transformer/signature regression tests.

## Rationale

This preserves legacy synchronous Bukkit semantics while ensuring the underlying CraftBlock/Level access runs under the region that owns the block location. It directly targets Multiverse-Core's `BlockSafety` startup path without introducing new control-flow into transformed plugin methods, so the StackMapFrame preservation work from #113 remains valid.