### PR TITLE
Delegate Folia world creation to TheNextLvl Worlds

### DIFF
--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/FoliaPatcher.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/FoliaPatcher.java
@@ -33,10 +33,6 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -58,23 +54,6 @@ public final class FoliaPatcher {
 
     /** リージョンスケジューラ応答待ちタイムアウト（秒）。デッドロック防止に使用。 */
     private static final long FUTURE_TIMEOUT_SECONDS = 5L;
-
-    /**
-     * ワールド生成専用のシングルスレッドエグゼキュータ。
-     * 非デーモンスレッドを使用してサーバー停止時の中断を防ぐ。
-     */
-    private static final ExecutorService worldGenExecutor =
-            Executors.newSingleThreadExecutor(r -> {
-                Thread t = new Thread(r, "FoliaPhantom-WorldGen-Worker");
-                t.setDaemon(false);
-                return t;
-            });
-
-    static {
-        Runtime.getRuntime().addShutdownHook(
-                new Thread(FoliaPatcher::shutdownWorldGenExecutor,
-                        "FoliaPhantom-WorldGen-Shutdown"));
-    }
 
     /** プラグインインスタンス（プラグインモード時に onEnable で設定） */
     public static Plugin plugin;
@@ -254,7 +233,7 @@ public final class FoliaPatcher {
         return runTaskTimerAsynchronously(scheduler, plugin, task, delay, period).getTaskId();
     }
 
-    public static <T> Future<T> callSyncMethod(
+    public static <T> java.util.concurrent.Future<T> callSyncMethod(
             BukkitScheduler scheduler, Plugin plugin, Callable<T> task) {
         CompletableFuture<T> future = new CompletableFuture<>();
         runTask(scheduler, plugin, () -> {
@@ -354,7 +333,6 @@ public final class FoliaPatcher {
         try {
             return future.get(FUTURE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         } catch (Exception e) {
-            // タイムアウト時にフォールバック実行するとスケジュール済みタスクと二重実行になるため行わない
             log.warn("breakNaturally timed out; scheduled task will still execute on correct region", e);
             return false;
         }
@@ -810,15 +788,7 @@ public final class FoliaPatcher {
     // ========================================================================
 
     public static World createWorld(WorldCreator creator) {
-        Future<World> future = worldGenExecutor.submit(creator::createWorld);
-        try {
-            return future.get();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("World creation was interrupted", e);
-        } catch (ExecutionException e) {
-            throw new RuntimeException("Failed to create world: " + creator.name(), e.getCause());
-        }
+        return WorldsBackend.createWorld(creator);
     }
 
     public static ChunkGenerator getDefaultWorldGenerator(
@@ -884,13 +854,8 @@ public final class FoliaPatcher {
         log.info("Cancelled all running tasks");
     }
 
-    /**
-     * FoliaPatcher を安全にシャットダウンする。
-     * プラグインモードでは onDisable から呼び出す。
-     */
     public static void shutdown() {
         cancelAllTasks();
-        shutdownWorldGenExecutor();
         log.info("FoliaPatcher shut down");
     }
 
@@ -898,13 +863,6 @@ public final class FoliaPatcher {
     // 内部ヘルパー
     // ========================================================================
 
-    /**
-     * 1回限りのタスクをスケジュールし、完了後に runningTasks から自動削除する。
-     *
-     * <p>taskId を事前に確保してクロージャに取り込み、タスク完了の finally ブロックで
-     * マップから削除する。これにより繰り返しタスクではなく単発タスクのメモリリークを防ぐ。
-     * put 前にタスクが完了するレースコンディションは put 後の ExecutionState チェックで対処する。</p>
-     */
     private static BukkitTask scheduleOnce(Plugin plugin, Runnable task,
             TaskSchedulerFactory factory) {
         int taskId = taskIdCounter.getAndIncrement();
@@ -923,7 +881,6 @@ public final class FoliaPatcher {
         return result;
     }
 
-    /** 繰り返しタスク用のラッパー（自動削除なし）。 */
     private static BukkitTask wrapTask(Plugin plugin, ScheduledTask scheduledTask) {
         int taskId = taskIdCounter.getAndIncrement();
         FoliaBukkitTask task = new FoliaBukkitTask(taskId, plugin, scheduledTask);
@@ -962,23 +919,6 @@ public final class FoliaPatcher {
         return new FoliaBukkitTask(-1, plugin, ScheduledTaskStub.INSTANCE);
     }
 
-    private static void shutdownWorldGenExecutor() {
-        worldGenExecutor.shutdown();
-        try {
-            if (!worldGenExecutor.awaitTermination(30L, TimeUnit.SECONDS)) {
-                worldGenExecutor.shutdownNow();
-            }
-        } catch (InterruptedException e) {
-            worldGenExecutor.shutdownNow();
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    // ========================================================================
-    // 内部型定義
-    // ========================================================================
-
-    /** scheduleOnce のスケジューラファクトリ。 */
     @FunctionalInterface
     private interface TaskSchedulerFactory {
         ScheduledTask schedule(Consumer<ScheduledTask> action);

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/PluginPatcher.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/PluginPatcher.java
@@ -59,7 +59,8 @@ public final class PluginPatcher {
         "com/patch/foliaphantom/patcher/FoliaPatcher$FoliaChunkGenerator.class",
         "com/patch/foliaphantom/patcher/FoliaPatcher$ScheduledTaskStub.class",
         "com/patch/foliaphantom/patcher/FoliaPatcher$TaskSchedulerFactory.class",
-        "com/patch/foliaphantom/patcher/BlockReadBridge.class"
+        "com/patch/foliaphantom/patcher/BlockReadBridge.class",
+        "com/patch/foliaphantom/patcher/WorldsBackend.class"
     };
 
     private final List<ClassTransformer> transformers;
@@ -170,10 +171,6 @@ public final class PluginPatcher {
         }
     }
 
-    /**
-     * Browser mode disables parallel ASM work. Stream each retained entry directly to the output
-     * so expanded JAR contents are not all retained in Java memory at once.
-     */
     private void writeSequentialEntries(
             Path jarPath, Path outputPath, ClassLoader frameClassLoader) throws IOException {
         try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(outputPath))) {

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/WorldsBackend.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/WorldsBackend.java
@@ -49,7 +49,8 @@ public final class WorldsBackend {
             invokeBuilder(builder, "seed", Long.class, creator.seed());
             invokeBuilder(builder, "structures", Boolean.class, creator.generateStructures());
             invokeBuilder(builder, "hardcore", Boolean.class, creator.hardcore());
-            invokeBuilder(builder, "bonusChest", Boolean.class, creator.bonusChest());
+            invokeBuilder(builder, "bonusChest", Boolean.class,
+                    optionalBooleanProperty(creator, "bonusChest", false));
             invokeBuilder(builder, "dimension", dimensionClass, dimensionFor(creator, dimensionClass));
             invokeBuilder(builder, "generatorType", generatorTypeClass,
                     generatorTypeFor(creator, generatorTypeClass));
@@ -107,6 +108,17 @@ public final class WorldsBackend {
         Field field = target.getClass().getDeclaredField(name);
         field.setAccessible(true);
         field.set(target, value);
+    }
+
+    private static boolean optionalBooleanProperty(
+            WorldCreator creator, String methodName, boolean defaultValue) {
+        try {
+            Method method = creator.getClass().getMethod(methodName);
+            Object value = method.invoke(creator);
+            return value instanceof Boolean bool ? bool : defaultValue;
+        } catch (ReflectiveOperationException ignored) {
+            return defaultValue;
+        }
     }
 
     private static Object dimensionFor(WorldCreator creator, Class<?> dimensionClass)

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/WorldsBackend.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/WorldsBackend.java
@@ -1,0 +1,96 @@
+package com.patch.foliaphantom.patcher;
+
+import org.bukkit.World;
+import org.bukkit.WorldCreator;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Optional runtime adapter for TheNextLvl Worlds.
+ *
+ * <p>Folia disables CraftServer#createWorld directly. Worlds implements the full
+ * Folia-aware NMS lifecycle itself, so patched plugins can delegate world creation
+ * to it when the plugin is installed instead of calling Bukkit#createWorld.</p>
+ */
+public final class WorldsBackend {
+
+    private WorldsBackend() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static World createWorld(WorldCreator creator) {
+        try {
+            ClassLoader loader = Thread.currentThread().getContextClassLoader();
+            Class<?> worldsAccessClass = Class.forName("net.thenextlvl.worlds.WorldsAccess", true, loader);
+            Class<?> levelClass = Class.forName("net.thenextlvl.worlds.Level", true, loader);
+            Class<?> keyClass = Class.forName("net.kyori.adventure.key.Key", true, loader);
+            Class<?> dimensionClass = Class.forName("net.thenextlvl.worlds.Dimension", true, loader);
+            Class<?> generatorTypeClass = Class.forName("net.thenextlvl.worlds.generator.GeneratorType", true, loader);
+
+            Object key = keyClass.getMethod("key", String.class, String.class)
+                    .invoke(null, "minecraft", sanitizeKey(creator.name()));
+            Object builder = levelClass.getMethod("builder", keyClass).invoke(null, key);
+
+            invokeBuilder(builder, "seed", Long.class, creator.seed());
+            invokeBuilder(builder, "structures", Boolean.class, creator.generateStructures());
+            invokeBuilder(builder, "dimension", dimensionClass, dimensionFor(creator, dimensionClass));
+            invokeBuilder(builder, "generatorType", generatorTypeClass,
+                    generatorTypeFor(creator, generatorTypeClass));
+
+            Object level = builder.getClass().getMethod("build").invoke(builder);
+            Object access = worldsAccessClass.getMethod("access").invoke(null);
+            @SuppressWarnings("unchecked")
+            CompletableFuture<World> future = (CompletableFuture<World>) worldsAccessClass
+                    .getMethod("create", levelClass)
+                    .invoke(access, level);
+            return future.join();
+        } catch (ClassNotFoundException exception) {
+            throw new UnsupportedOperationException(
+                    "Folia does not support Bukkit.createWorld directly. Install TheNextLvl Worlds "
+                            + "to provide the Folia-aware world creation backend.", exception);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Failed to invoke TheNextLvl Worlds backend", exception);
+        }
+    }
+
+    private static Object dimensionFor(WorldCreator creator, Class<?> dimensionClass)
+            throws ReflectiveOperationException {
+        String fieldName = switch (creator.environment()) {
+            case NETHER -> "THE_NETHER";
+            case THE_END -> "THE_END";
+            default -> "OVERWORLD";
+        };
+        return staticField(dimensionClass, fieldName);
+    }
+
+    private static Object generatorTypeFor(WorldCreator creator, Class<?> generatorTypeClass)
+            throws ReflectiveOperationException {
+        String fieldName = switch (creator.type()) {
+            case FLAT -> "FLAT";
+            case AMPLIFIED -> "AMPLIFIED";
+            case LARGE_BIOMES -> "LARGE_BIOMES";
+            default -> "NORMAL";
+        };
+        return staticField(generatorTypeClass, fieldName);
+    }
+
+    private static Object staticField(Class<?> type, String name) throws ReflectiveOperationException {
+        Field field = type.getField(name);
+        return field.get(null);
+    }
+
+    private static void invokeBuilder(Object builder, String methodName, Class<?> parameterType, Object value)
+            throws ReflectiveOperationException {
+        Method method = builder.getClass().getMethod(methodName, parameterType);
+        method.invoke(builder, value);
+    }
+
+    private static String sanitizeKey(String name) {
+        String normalized = name.toLowerCase(java.util.Locale.ROOT)
+                .replace(' ', '_')
+                .replaceAll("[^a-z0-9._/-]", "_");
+        return normalized.isEmpty() ? "world" : normalized;
+    }
+}

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/WorldsBackend.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/WorldsBackend.java
@@ -1,7 +1,10 @@
 package com.patch.foliaphantom.patcher;
 
+import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.WorldCreator;
+import org.bukkit.generator.BiomeProvider;
+import org.bukkit.generator.ChunkGenerator;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -13,6 +16,14 @@ import java.util.concurrent.CompletableFuture;
  * <p>Folia disables CraftServer#createWorld directly. Worlds implements the full
  * Folia-aware NMS lifecycle itself, so patched plugins can delegate world creation
  * to it when the plugin is installed instead of calling Bukkit#createWorld.</p>
+ *
+ * <p>The Worlds public {@code Level.Builder} models plugin generators through its
+ * own {@code Generator} abstraction and does not expose setters for already-resolved
+ * Bukkit {@link ChunkGenerator}/{@link BiomeProvider} instances. Bukkit's
+ * {@link WorldCreator}, however, stores the final resolved instances. To preserve
+ * compatibility with arbitrary generator plugins, this bridge injects those resolved
+ * instances into the built Worlds level before creation. Worlds itself consumes them
+ * through {@code Level#getChunkGenerator()} and {@code Level#getBiomeProvider()}.</p>
  */
 public final class WorldsBackend {
 
@@ -22,24 +33,36 @@ public final class WorldsBackend {
 
     public static World createWorld(WorldCreator creator) {
         try {
-            ClassLoader loader = Thread.currentThread().getContextClassLoader();
+            ClassLoader loader = findWorldsClassLoader();
             Class<?> worldsAccessClass = Class.forName("net.thenextlvl.worlds.WorldsAccess", true, loader);
             Class<?> levelClass = Class.forName("net.thenextlvl.worlds.Level", true, loader);
             Class<?> keyClass = Class.forName("net.kyori.adventure.key.Key", true, loader);
             Class<?> dimensionClass = Class.forName("net.thenextlvl.worlds.Dimension", true, loader);
-            Class<?> generatorTypeClass = Class.forName("net.thenextlvl.worlds.generator.GeneratorType", true, loader);
+            Class<?> generatorTypeClass = Class.forName(
+                    "net.thenextlvl.worlds.generator.GeneratorType", true, loader);
 
+            NamespacedKey bukkitKey = creator.key();
             Object key = keyClass.getMethod("key", String.class, String.class)
-                    .invoke(null, "minecraft", sanitizeKey(creator.name()));
+                    .invoke(null, bukkitKey.getNamespace(), bukkitKey.getKey());
             Object builder = levelClass.getMethod("builder", keyClass).invoke(null, key);
 
             invokeBuilder(builder, "seed", Long.class, creator.seed());
             invokeBuilder(builder, "structures", Boolean.class, creator.generateStructures());
+            invokeBuilder(builder, "hardcore", Boolean.class, creator.hardcore());
+            invokeBuilder(builder, "bonusChest", Boolean.class, creator.bonusChest());
             invokeBuilder(builder, "dimension", dimensionClass, dimensionFor(creator, dimensionClass));
             invokeBuilder(builder, "generatorType", generatorTypeClass,
                     generatorTypeFor(creator, generatorTypeClass));
 
             Object level = builder.getClass().getMethod("build").invoke(builder);
+
+            // WorldCreator already contains the final generator instances after Bukkit has
+            // resolved plugin:id strings. Preserve them verbatim instead of trying to infer
+            // the providing plugin/id again. This supports arbitrary ChunkGenerator and
+            // BiomeProvider implementations, including generators not represented by the
+            // Worlds Generator abstraction.
+            injectResolvedGenerator(level, creator.generator(), creator.biomeProvider());
+
             Object access = worldsAccessClass.getMethod("access").invoke(null);
             @SuppressWarnings("unchecked")
             CompletableFuture<World> future = (CompletableFuture<World>) worldsAccessClass
@@ -53,6 +76,37 @@ public final class WorldsBackend {
         } catch (ReflectiveOperationException exception) {
             throw new IllegalStateException("Failed to invoke TheNextLvl Worlds backend", exception);
         }
+    }
+
+    private static ClassLoader findWorldsClassLoader() throws ClassNotFoundException {
+        // On Paper/Folia, plugin classes are generally not visible through another plugin's
+        // class loader. Resolve the installed Worlds plugin first and use its loader.
+        org.bukkit.plugin.Plugin worlds = org.bukkit.Bukkit.getPluginManager().getPlugin("Worlds");
+        if (worlds != null) {
+            return worlds.getClass().getClassLoader();
+        }
+
+        ClassLoader context = Thread.currentThread().getContextClassLoader();
+        Class.forName("net.thenextlvl.worlds.WorldsAccess", false, context);
+        return context;
+    }
+
+    private static void injectResolvedGenerator(
+            Object level, ChunkGenerator generator, BiomeProvider biomeProvider)
+            throws ReflectiveOperationException {
+        if (generator != null) {
+            setField(level, "chunkGenerator", generator);
+        }
+        if (biomeProvider != null) {
+            setField(level, "biomeProvider", biomeProvider);
+        }
+    }
+
+    private static void setField(Object target, String name, Object value)
+            throws ReflectiveOperationException {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
     }
 
     private static Object dimensionFor(WorldCreator creator, Class<?> dimensionClass)
@@ -85,12 +139,5 @@ public final class WorldsBackend {
             throws ReflectiveOperationException {
         Method method = builder.getClass().getMethod(methodName, parameterType);
         method.invoke(builder, value);
-    }
-
-    private static String sanitizeKey(String name) {
-        String normalized = name.toLowerCase(java.util.Locale.ROOT)
-                .replace(' ', '_')
-                .replaceAll("[^a-z0-9._/-]", "_");
-        return normalized.isEmpty() ? "world" : normalized;
     }
 }


### PR DESCRIPTION
## Summary

Replace Pasta's unsupported `WorldCreator.createWorld()` fallback with an optional runtime backend powered by [TheNextLvl Worlds](https://github.com/TheNextLvl-net/worlds).

Folia deliberately throws `UnsupportedOperationException` from `CraftServer#createWorld`, so moving `WorldCreator.createWorld()` to a worker thread can never work. TheNextLvl Worlds solves this by implementing the complete Folia-aware world lifecycle itself (`PaperWorldLoader`, `ServerLevel`, `addLevel`, `initWorld`, entity-manager startup, and level preparation).

## Changes

- Add `WorldsBackend`, loaded reflectively so Pasta has no compile-time dependency on Worlds.
- Convert Bukkit `WorldCreator` properties into a Worlds `Level.Builder`:
  - exact NamespacedKey
  - seed
  - environment/dimension
  - generateStructures
  - hardcore / bonus chest
  - NORMAL / FLAT / AMPLIFIED / LARGE_BIOMES generator type
- Preserve arbitrary already-resolved Bukkit generation implementations:
  - `WorldCreator.generator()` raw `ChunkGenerator`
  - `WorldCreator.biomeProvider()` raw `BiomeProvider`
- Inject those resolved instances into the built Worlds level so Worlds' existing `getChunkGenerator()` / `getBiomeProvider()` path consumes them directly. This supports generator plugins regardless of whether they came from `plugin:id`, Multiverse resolution, or direct `WorldCreator.generator(new CustomGenerator())` assignment.
- Resolve Worlds through its plugin class loader to avoid Paper/Folia plugin class-loader isolation issues.
- Delegate creation to `WorldsAccess.access().create(level)` and preserve Bukkit's synchronous `WorldCreator.createWorld()` contract with `join()`.
- Bundle the backend into patched plugin jars.
- Remove the ineffective `FoliaPhantom-WorldGen-Worker` executor and its shutdown hook.
- If Worlds is not installed, fail with an explicit message instead of invoking Folia's unsupported `CraftServer#createWorld`.

## Why this approach

TheNextLvl Worlds already owns the version-specific Folia/NMS implementation. Delegating to its world lifecycle keeps Pasta free of brittle NMS constructor/signature copies. Bukkit's `WorldCreator` has already resolved named generator providers to concrete `ChunkGenerator`/`BiomeProvider` instances, so preserving those instances is the most general compatibility path.

## Runtime requirement

Requires a compatible TheNextLvl Worlds plugin at runtime.