### PR TITLE
Avoid startup deadlock for block reads

### DIFF
--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/BlockReadBridge.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/BlockReadBridge.java
@@ -1,6 +1,7 @@
 package com.patch.foliaphantom.patcher;
 
 import org.bukkit.Bukkit;
+import org.bukkit.ChunkSnapshot;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -21,23 +22,33 @@ import java.util.function.Supplier;
  * Region-owned synchronous Block reads used by patched plugins.
  *
  * <p>Legacy plugins frequently read block state during lifecycle callbacks that run on Folia's
- * global thread. CraftBlock ultimately touches region-owned Level state, so these reads must be
- * executed by the owning region. The bridge preserves the original synchronous Bukkit API contract
- * by dispatching the read and waiting for the result.</p>
+ * startup/global thread. During normal ticking, CraftBlock reads must execute on the owning region.
+ * During server startup, however, region tasks cannot make progress while plugin enablement is
+ * still blocking server initialisation. For immutable block data that ChunkSnapshot can represent,
+ * this bridge therefore reads from a snapshot on the non-ticking startup thread instead of
+ * dispatching a region task and deadlocking.</p>
  */
 public final class BlockReadBridge {
 
     private static final long READ_TIMEOUT_SECONDS = 5L;
+    private static final String FOLIA_TICK_THREAD_RUNNER =
+            "io.papermc.paper.threadedregions.TickRegionScheduler$TickThreadRunner";
 
     private BlockReadBridge() {
         throw new UnsupportedOperationException("Utility class");
     }
 
     public static Material getType(Block block) {
+        if (isStartupThread()) {
+            return snapshot(block).getBlockType(localX(block), block.getY(), localZ(block));
+        }
         return read(block, block::getType);
     }
 
     public static BlockData getBlockData(Block block) {
+        if (isStartupThread()) {
+            return snapshot(block).getBlockData(localX(block), block.getY(), localZ(block));
+        }
         return read(block, block::getBlockData);
     }
 
@@ -51,6 +62,33 @@ public final class BlockReadBridge {
 
     public static Collection<ItemStack> getDrops(Block block, ItemStack tool) {
         return read(block, () -> block.getDrops(tool));
+    }
+
+    private static ChunkSnapshot snapshot(Block block) {
+        // Plugin enablement runs before region ticking starts. At that point there is no
+        // concurrent region mutation for the startup world, and a snapshot avoids touching
+        // Level#getCurrentWorldData through CraftBlock#getType/getBlockData.
+        return block.getChunk().getChunkSnapshot(false, false, false);
+    }
+
+    private static int localX(Block block) {
+        return block.getX() & 15;
+    }
+
+    private static int localZ(Block block) {
+        return block.getZ() & 15;
+    }
+
+    private static boolean isStartupThread() {
+        Thread thread = Thread.currentThread();
+        Class<?> type = thread.getClass();
+        while (type != null) {
+            if (FOLIA_TICK_THREAD_RUNNER.equals(type.getName())) {
+                return false;
+            }
+            type = type.getSuperclass();
+        }
+        return Bukkit.isPrimaryThread();
     }
 
     private static <T> T read(Block block, Supplier<T> operation) {


### PR DESCRIPTION
## Summary

Fix `BlockReadBridge` timeouts during plugin enablement on Folia.

During `JavaPlugin#onEnable`, server startup is still blocking region scheduling. The existing bridge dispatches `Block#getType` / `getBlockData` to the owning region and synchronously waits, which deadlocks until the 5 second timeout.

## Changes

- Detect Folia tick threads (`TickThreadRunner`) separately from the non-ticking server startup thread.
- On the startup thread only, serve immutable `Block#getType` and `Block#getBlockData` reads from `ChunkSnapshot` instead of scheduling a region task.
- Keep normal region-owned dispatch for reads during ticking.
- Keep `getState` / `getDrops` on region dispatch because a snapshot cannot preserve their full Bukkit semantics.

## Why

This fixes Multiverse-Core spawn safety checks during `onEnable` without returning fabricated block values and without blocking startup waiting for a region scheduler that cannot progress yet.