### PR TITLE
Use loaded NMS chunks for startup block reads

### DIFF
--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/BlockReadBridge.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/BlockReadBridge.java
@@ -1,7 +1,6 @@
 package com.patch.foliaphantom.patcher;
 
 import org.bukkit.Bukkit;
-import org.bukkit.ChunkSnapshot;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -11,6 +10,8 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -24,15 +25,13 @@ import java.util.function.Supplier;
  * <p>Legacy plugins frequently read block state during lifecycle callbacks that run on Folia's
  * startup/global thread. During normal ticking, CraftBlock reads must execute on the owning region.
  * During server startup, however, region tasks cannot make progress while plugin enablement is
- * still blocking server initialisation. For immutable block data that ChunkSnapshot can represent,
- * this bridge therefore reads from a snapshot on the non-ticking startup thread instead of
- * dispatching a region task and deadlocking.</p>
+ * still blocking server initialisation. Startup reads therefore use Paper's loaded-chunk-only NMS
+ * path and never request, generate, or ticket a chunk.</p>
  */
 public final class BlockReadBridge {
 
     private static final long READ_TIMEOUT_SECONDS = 5L;
-    private static final String FOLIA_TICK_THREAD_RUNNER =
-            "io.papermc.paper.threadedregions.TickRegionScheduler$TickThreadRunner";
+    private static final String STARTUP_THREAD_NAME = "Server thread";
 
     private BlockReadBridge() {
         throw new UnsupportedOperationException("Utility class");
@@ -40,14 +39,14 @@ public final class BlockReadBridge {
 
     public static Material getType(Block block) {
         if (isStartupThread()) {
-            return snapshot(block).getBlockType(localX(block), block.getY(), localZ(block));
+            return startupMaterial(block);
         }
         return read(block, block::getType);
     }
 
     public static BlockData getBlockData(Block block) {
         if (isStartupThread()) {
-            return snapshot(block).getBlockData(localX(block), block.getY(), localZ(block));
+            return startupBlockData(block);
         }
         return read(block, block::getBlockData);
     }
@@ -64,31 +63,68 @@ public final class BlockReadBridge {
         return read(block, () -> block.getDrops(tool));
     }
 
-    private static ChunkSnapshot snapshot(Block block) {
-        // Plugin enablement runs before region ticking starts. At that point there is no
-        // concurrent region mutation for the startup world, and a snapshot avoids touching
-        // Level#getCurrentWorldData through CraftBlock#getType/getBlockData.
-        return block.getChunk().getChunkSnapshot(false, false, false);
+    private static Material startupMaterial(Block block) {
+        Object state = startupBlockState(block);
+        try {
+            Method getBukkitMaterial = state.getClass().getMethod("getBukkitMaterial");
+            return (Material) getBukkitMaterial.invoke(state);
+        } catch (ReflectiveOperationException exception) {
+            throw startupReadFailure(block, exception);
+        }
     }
 
-    private static int localX(Block block) {
-        return block.getX() & 15;
+    private static BlockData startupBlockData(Block block) {
+        Object state = startupBlockState(block);
+        try {
+            ClassLoader loader = state.getClass().getClassLoader();
+            Class<?> blockStateClass = Class.forName(
+                    "net.minecraft.world.level.block.state.BlockState", true, loader);
+            Class<?> craftBlockDataClass = Class.forName(
+                    "org.bukkit.craftbukkit.block.data.CraftBlockData", true, loader);
+            Method createData = craftBlockDataClass.getMethod("createData", blockStateClass);
+            return (BlockData) createData.invoke(null, state);
+        } catch (ReflectiveOperationException exception) {
+            throw startupReadFailure(block, exception);
+        }
     }
 
-    private static int localZ(Block block) {
-        return block.getZ() & 15;
+    private static Object startupBlockState(Block block) {
+        try {
+            Object craftWorld = block.getWorld();
+            Method getHandle = craftWorld.getClass().getMethod("getHandle");
+            Object serverLevel = getHandle.invoke(craftWorld);
+
+            Method getChunkSource = serverLevel.getClass().getMethod("getChunkSource");
+            Object chunkSource = getChunkSource.invoke(serverLevel);
+            Method getLoadedChunk = chunkSource.getClass().getMethod(
+                    "getChunkAtIfLoadedImmediately", int.class, int.class);
+            Object chunk = getLoadedChunk.invoke(
+                    chunkSource, Math.floorDiv(block.getX(), 16), Math.floorDiv(block.getZ(), 16));
+            if (chunk == null) {
+                throw new IllegalStateException(
+                        "Startup block read requires an already-loaded chunk at " + block.getLocation());
+            }
+
+            ClassLoader loader = serverLevel.getClass().getClassLoader();
+            Class<?> blockPosClass = Class.forName("net.minecraft.core.BlockPos", true, loader);
+            Constructor<?> blockPosConstructor = blockPosClass.getConstructor(
+                    int.class, int.class, int.class);
+            Object blockPos = blockPosConstructor.newInstance(block.getX(), block.getY(), block.getZ());
+            Method getBlockState = chunk.getClass().getMethod("getBlockState", blockPosClass);
+            return getBlockState.invoke(chunk, blockPos);
+        } catch (ReflectiveOperationException exception) {
+            throw startupReadFailure(block, exception);
+        }
+    }
+
+    private static IllegalStateException startupReadFailure(Block block, Throwable cause) {
+        return new IllegalStateException(
+                "Failed loaded-chunk startup block read at " + block.getLocation(), cause);
     }
 
     private static boolean isStartupThread() {
         Thread thread = Thread.currentThread();
-        Class<?> type = thread.getClass();
-        while (type != null) {
-            if (FOLIA_TICK_THREAD_RUNNER.equals(type.getName())) {
-                return false;
-            }
-            type = type.getSuperclass();
-        }
-        return Bukkit.isPrimaryThread();
+        return Bukkit.isPrimaryThread() && STARTUP_THREAD_NAME.equals(thread.getName());
     }
 
     private static <T> T read(Block block, Supplier<T> operation) {


### PR DESCRIPTION
## Summary

Replace the startup `ChunkSnapshot` fallback in `BlockReadBridge` with a loaded-chunk-only NMS read path.

The snapshot approach still called `CraftBlock#getChunk()` → `CraftWorld#getChunkAt()`, which Folia rejects on the startup `Server thread` as async chunk retrieval.

## Changes

- Detect the startup phase specifically via the primary `Server thread` instead of the incorrect `TickThreadRunner` class-name check.
- For startup `Block#getType` / `getBlockData`, reflectively use:
  - `CraftWorld#getHandle()`
  - `ServerLevel#getChunkSource()`
  - `ServerChunkCache#getChunkAtIfLoadedImmediately(x,z)`
  - `LevelChunk#getBlockState(BlockPos)`
- Convert NMS `BlockState` back to Bukkit `Material` via `getBukkitMaterial()` and to exact `BlockData` via `CraftBlockData.createData(BlockState)`.
- Never add chunk tickets, request async retrieval, generate chunks, or wait on a region scheduler during plugin enablement.
- If the required chunk is not already loaded, fail explicitly rather than silently fabricating block data.

Normal ticking reads still use the owning region scheduler.